### PR TITLE
Support for converting to typed slices.

### DIFF
--- a/builtins/core.go
+++ b/builtins/core.go
@@ -3,11 +3,12 @@ package core
 
 import (
 	"fmt"
-	"github.com/mattn/anko/parser"
-	"github.com/mattn/anko/vm"
 	"io/ioutil"
 	"os"
 	"reflect"
+
+	"github.com/mattn/anko/parser"
+	"github.com/mattn/anko/vm"
 )
 
 func Import(env *vm.Env) *vm.Env {
@@ -113,6 +114,30 @@ func Import(env *vm.Env) *vm.Env {
 		return []rune(s)[0]
 	}))
 
+	env.Define("toBoolSlice", reflect.ValueOf(func(v []interface{}) []bool {
+		var result []bool
+		toSlice(v, &result)
+		return result
+	}))
+
+	env.Define("toFloatSlice", reflect.ValueOf(func(v []interface{}) []float64 {
+		var result []float64
+		toSlice(v, &result)
+		return result
+	}))
+
+	env.Define("toIntSlice", reflect.ValueOf(func(v []interface{}) []int64 {
+		var result []int64
+		toSlice(v, &result)
+		return result
+	}))
+
+	env.Define("toStringSlice", reflect.ValueOf(func(v []interface{}) []string {
+		var result []string
+		toSlice(v, &result)
+		return result
+	}))
+
 	env.Define("string", reflect.ValueOf(func(b []byte) string {
 		return string(b)
 	}))
@@ -161,4 +186,25 @@ func Import(env *vm.Env) *vm.Env {
 	env.Define("printf", reflect.ValueOf(fmt.Printf))
 
 	return env
+}
+
+// toSlice takes in a "generic" slice and converts and copies
+// it's elements into the typed slice pointed at by ptr.
+// Note that this is a costly operation.
+func toSlice(from []interface{}, ptr interface{}) {
+	// Value of the pointer to the target
+	obj := reflect.Indirect(reflect.ValueOf(ptr))
+	// We can't just convert from interface{} to whatever the target is (diff memory layout),
+	// so we need to create a New slice of the proper type and copy the values individually
+	t := reflect.TypeOf(ptr).Elem()
+	slice := reflect.MakeSlice(t, len(from), len(from))
+	// Copying the data, val is an adressable Pointer of the actual target type
+	val := reflect.Indirect(reflect.New(t.Elem()))
+	for i := 0; i < len(from); i++ {
+		v := reflect.ValueOf(from[i])
+		val.Set(v)
+		slice.Index(i).Set(v)
+	}
+	// Ok now assign our slice to the target pointer
+	obj.Set(slice)
 }


### PR DESCRIPTION
This allows converting generic slices ([]interface{}) into typed slices.
Makes it easier to call Go code that takes in typed arrays / varargs. 