### PR TITLE
A mechanism to interrupt the execution.

### DIFF
--- a/vm/env.go
+++ b/vm/env.go
@@ -9,46 +9,55 @@ import (
 // Env provides interface to run VM. This mean function scope and blocked-scope.
 // If stack go to blocked-scope, it will make new Env.
 type Env struct {
-	name   string
-	env    map[string]reflect.Value
-	typ    map[string]reflect.Type
-	parent *Env
+	name      string
+	env       map[string]reflect.Value
+	typ       map[string]reflect.Type
+	parent    *Env
+	interrupt *bool
 }
 
 // NewEnv create new global scope.
 func NewEnv() *Env {
+	b := false
+
 	return &Env{
-		env:    make(map[string]reflect.Value),
-		typ:    make(map[string]reflect.Type),
-		parent: nil,
+		env:       make(map[string]reflect.Value),
+		typ:       make(map[string]reflect.Type),
+		parent:    nil,
+		interrupt: &b,
 	}
 }
 
 // NewEnv create new child scope.
 func (e *Env) NewEnv() *Env {
 	return &Env{
-		env:    make(map[string]reflect.Value),
-		typ:    make(map[string]reflect.Type),
-		parent: e,
-		name:   e.name,
+		env:       make(map[string]reflect.Value),
+		typ:       make(map[string]reflect.Type),
+		parent:    e,
+		name:      e.name,
+		interrupt: e.interrupt,
 	}
 }
 
 func NewPackage(n string) *Env {
+	b := false
+
 	return &Env{
-		env:    make(map[string]reflect.Value),
-		typ:    make(map[string]reflect.Type),
-		parent: nil,
-		name:   n,
+		env:       make(map[string]reflect.Value),
+		typ:       make(map[string]reflect.Type),
+		parent:    nil,
+		name:      n,
+		interrupt: &b,
 	}
 }
 
 func (e *Env) NewPackage(n string) *Env {
 	return &Env{
-		env:    make(map[string]reflect.Value),
-		typ:    make(map[string]reflect.Type),
-		parent: e,
-		name:   n,
+		env:       make(map[string]reflect.Value),
+		typ:       make(map[string]reflect.Type),
+		parent:    e,
+		name:      n,
+		interrupt: e.interrupt,
 	}
 }
 

--- a/vm/example_test.go
+++ b/vm/example_test.go
@@ -1,0 +1,51 @@
+package vm_test
+
+import (
+	"fmt"
+	"github.com/mattn/anko/parser"
+	"github.com/mattn/anko/vm"
+	"log"
+	"reflect"
+	"time"
+)
+
+func ExampleInterrupt() {
+	env := vm.NewEnv()
+
+	sleepFunc := func(spec string) {
+		d, err := time.ParseDuration(spec)
+		if err != nil {
+			panic(err)
+		}
+
+		time.Sleep(d)
+	}
+
+	env.Define("println", reflect.ValueOf(fmt.Println))
+	env.Define("sleep", reflect.ValueOf(sleepFunc))
+
+	script := `
+sleep("2s")
+# Should interrupt here.
+# The next line will not be executed.
+println("<this should not be printed>")
+`
+
+	scanner := new(parser.Scanner)
+	scanner.Init(script)
+	stmts, err := parser.Parse(scanner)
+	if err != nil {
+		log.Fatal()
+	}
+
+	// Interrupts after 1 second.
+	go func() {
+		time.Sleep(time.Second * 1)
+		vm.Interrupt(env)
+	}()
+
+	v, err := vm.Run(stmts, env)
+	fmt.Println(v, err)
+	// output:
+	// <nil> Execution interrupted
+}


### PR DESCRIPTION
This is a proposal of a mechanism to interrupt the execution of a statements chain.

There are other ways to implement it -- for instance, using an interrupt channel --, but using a simple boolean check seems to have less of a performance burden.

A consequence is that the environment can get messy after an interrupt, but I am not fully aware of the internals, and so I ask for your review and feedback in this regard.

Also, calling Interrupt() in an environment which is not running causes the next Run() to fail. To fix that, it would be nice to, maybe in another PR, build a better API for the embedded functionality. I feel like RunSingleStmt should be an internal function and (a more user-friendly version of) Run should be the only entry point of execution (for embedders).