### PR TITLE
fix undefined symbol 'string' in examples

### DIFF
--- a/_example/scripts/http.ank
+++ b/_example/scripts/http.ank
@@ -4,5 +4,5 @@ var http, ioutil = import("net/http"), import("io/ioutil")
 
 r = http.DefaultClient.Get("http://www.google.com")
 b, a = ioutil.ReadAll(r[0].Body)
-println(string(b))
+printf("%s", b)
 r[0].Body.Close()

--- a/_example/scripts/socket.ank
+++ b/_example/scripts/socket.ank
@@ -23,4 +23,4 @@ b, e = ioutil.ReadAll(c)
 if e != nil {
   throw e
 }
-println(string(b))
+printf("%s", b)


### PR DESCRIPTION
Convertor func **string** [was replaced]( https://github.com/mattn/anko/commit/d9c438af3e18ddedc9d9d68d564900fbf2ce5bfe#diff-32b04d93ce30b8591f4ad2906b972927L141) by **toString**.

However affected examples need to display _[]byte_ as _string_ and **toString** would display it as _[]byte_, thus using printf("%s", ...) fixes this.