### PR TITLE
made it easy to load all builtins for the embedded use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,22 @@ fmt.Println(val)
 // 3
 ```
 
+To import all builtins, allowing the example scripts to work:
+
+```Go
+import anko_core "github.com/mattn/anko/builtins"
+
+var env = vm.NewEnv()
+anko_core.LoadAllBuiltins(env)
+
+_, err := env.Execute(`println("test")`)
+if err != nil {
+	panic(err)
+}
+// output:
+// "test"
+```
+
 Running scripts using anko command-line tool:
 
 ```

--- a/anko.go
+++ b/anko.go
@@ -18,29 +18,6 @@ import (
 	"github.com/mattn/go-isatty"
 
 	anko_core "github.com/mattn/anko/builtins"
-	anko_encoding_json "github.com/mattn/anko/builtins/encoding/json"
-	anko_errors "github.com/mattn/anko/builtins/errors"
-	anko_flag "github.com/mattn/anko/builtins/flag"
-	anko_fmt "github.com/mattn/anko/builtins/fmt"
-	anko_io "github.com/mattn/anko/builtins/io"
-	anko_io_ioutil "github.com/mattn/anko/builtins/io/ioutil"
-	anko_math "github.com/mattn/anko/builtins/math"
-	anko_math_rand "github.com/mattn/anko/builtins/math/rand"
-	anko_net "github.com/mattn/anko/builtins/net"
-	anko_net_http "github.com/mattn/anko/builtins/net/http"
-	anko_net_url "github.com/mattn/anko/builtins/net/url"
-	anko_os "github.com/mattn/anko/builtins/os"
-	anko_os_exec "github.com/mattn/anko/builtins/os/exec"
-	anko_os_signal "github.com/mattn/anko/builtins/os/signal"
-	anko_path "github.com/mattn/anko/builtins/path"
-	anko_path_filepath "github.com/mattn/anko/builtins/path/filepath"
-	anko_regexp "github.com/mattn/anko/builtins/regexp"
-	anko_runtime "github.com/mattn/anko/builtins/runtime"
-	anko_sort "github.com/mattn/anko/builtins/sort"
-	anko_strings "github.com/mattn/anko/builtins/strings"
-	anko_time "github.com/mattn/anko/builtins/time"
-
-	anko_colortext "github.com/mattn/anko/builtins/github.com/daviddengcn/go-colortext"
 )
 
 const version = "0.0.1"
@@ -106,40 +83,7 @@ func main() {
 		os.Args = fs.Args()
 	}
 
-	anko_core.Import(env)
-
-	pkgs := map[string]func(env *vm.Env) *vm.Env{
-		"encoding/json": anko_encoding_json.Import,
-		"errors":        anko_errors.Import,
-		"flag":          anko_flag.Import,
-		"fmt":           anko_fmt.Import,
-		"io":            anko_io.Import,
-		"io/ioutil":     anko_io_ioutil.Import,
-		"math":          anko_math.Import,
-		"math/rand":     anko_math_rand.Import,
-		"net":           anko_net.Import,
-		"net/http":      anko_net_http.Import,
-		"net/url":       anko_net_url.Import,
-		"os":            anko_os.Import,
-		"os/exec":       anko_os_exec.Import,
-		"os/signal":     anko_os_signal.Import,
-		"path":          anko_path.Import,
-		"path/filepath": anko_path_filepath.Import,
-		"regexp":        anko_regexp.Import,
-		"runtime":       anko_runtime.Import,
-		"sort":          anko_sort.Import,
-		"strings":       anko_strings.Import,
-		"time":          anko_time.Import,
-		"github.com/daviddengcn/go-colortext": anko_colortext.Import,
-	}
-
-	env.Define("import", func(s string) interface{} {
-		if loader, ok := pkgs[s]; ok {
-			m := loader(env)
-			return m
-		}
-		panic(fmt.Sprintf("package '%s' not found", s))
-	})
+	anko_core.LoadAllBuiltins(env)
 
 	for {
 		if interactive {

--- a/builtins/core.go
+++ b/builtins/core.go
@@ -9,8 +9,71 @@ import (
 
 	"github.com/mattn/anko/parser"
 	"github.com/mattn/anko/vm"
+
+	anko_encoding_json "github.com/mattn/anko/builtins/encoding/json"
+	anko_errors "github.com/mattn/anko/builtins/errors"
+	anko_flag "github.com/mattn/anko/builtins/flag"
+	anko_fmt "github.com/mattn/anko/builtins/fmt"
+	anko_io "github.com/mattn/anko/builtins/io"
+	anko_io_ioutil "github.com/mattn/anko/builtins/io/ioutil"
+	anko_math "github.com/mattn/anko/builtins/math"
+	anko_math_rand "github.com/mattn/anko/builtins/math/rand"
+	anko_net "github.com/mattn/anko/builtins/net"
+	anko_net_http "github.com/mattn/anko/builtins/net/http"
+	anko_net_url "github.com/mattn/anko/builtins/net/url"
+	anko_os "github.com/mattn/anko/builtins/os"
+	anko_os_exec "github.com/mattn/anko/builtins/os/exec"
+	anko_os_signal "github.com/mattn/anko/builtins/os/signal"
+	anko_path "github.com/mattn/anko/builtins/path"
+	anko_path_filepath "github.com/mattn/anko/builtins/path/filepath"
+	anko_regexp "github.com/mattn/anko/builtins/regexp"
+	anko_runtime "github.com/mattn/anko/builtins/runtime"
+	anko_sort "github.com/mattn/anko/builtins/sort"
+	anko_strings "github.com/mattn/anko/builtins/strings"
+	anko_time "github.com/mattn/anko/builtins/time"
+
+	anko_colortext "github.com/mattn/anko/builtins/github.com/daviddengcn/go-colortext"
 )
 
+// LoadAllBuiltins is a convenience function that loads all defined builtins.
+func LoadAllBuiltins(env *vm.Env) {
+	Import(env)
+
+	pkgs := map[string]func(env *vm.Env) *vm.Env{
+		"encoding/json": anko_encoding_json.Import,
+		"errors":        anko_errors.Import,
+		"flag":          anko_flag.Import,
+		"fmt":           anko_fmt.Import,
+		"io":            anko_io.Import,
+		"io/ioutil":     anko_io_ioutil.Import,
+		"math":          anko_math.Import,
+		"math/rand":     anko_math_rand.Import,
+		"net":           anko_net.Import,
+		"net/http":      anko_net_http.Import,
+		"net/url":       anko_net_url.Import,
+		"os":            anko_os.Import,
+		"os/exec":       anko_os_exec.Import,
+		"os/signal":     anko_os_signal.Import,
+		"path":          anko_path.Import,
+		"path/filepath": anko_path_filepath.Import,
+		"regexp":        anko_regexp.Import,
+		"runtime":       anko_runtime.Import,
+		"sort":          anko_sort.Import,
+		"strings":       anko_strings.Import,
+		"time":          anko_time.Import,
+		"github.com/daviddengcn/go-colortext": anko_colortext.Import,
+	}
+
+	env.Define("import", func(s string) interface{} {
+		if loader, ok := pkgs[s]; ok {
+			m := loader(env)
+			return m
+		}
+		panic(fmt.Sprintf("package '%s' not found", s))
+	})
+}
+
+// Import defines core language builtins - len, range, println, int64, etc.
 func Import(env *vm.Env) *vm.Env {
 	env.Define("len", func(v interface{}) int64 {
 		rv := reflect.ValueOf(v)


### PR DESCRIPTION
I was testing anko for an embedded application, but had some issues getting examples to work.

I dug a bit (not too hard at this stage), and found that the built-ins aren't all loaded by default. I think this makes sense, but for evaluation purposes I'd like to be able to easily pull in all builtins; the exact set of desired functions can later be defined.

I factored out the builtin import code to core, and documented the change.