### PR TITLE
improved error message for bad syntax

### DIFF
--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -516,7 +516,9 @@ func (l *Lexer) Error(msg string) {
 func Parse(s *Scanner) ([]ast.Stmt, error) {
 	l := Lexer{s: s}
 	if yyParse(&l) != 0 {
-		return nil, l.e
+		badline := (l.pos.Line-1)/2
+		e := fmt.Errorf("%s at or before l%d:c%d, symbol '%s'", l.e, badline+1, l.pos.Column, l.lit)
+		return nil, e
 	}
 	return l.stmts, l.e
 }


### PR DESCRIPTION
I found debugging bad syntax to be difficult, so I improved the error message.

Instead of `syntax error`, an error will be `syntax error occurred at or before l16:c5, symbol '{'`

The line calculation is a little weird - I couldn't figure out why l.pos.Line incremented by 2 on my systems and I'm concerned it may not be cross-platform.

It is working for me on both Linux and OSX.