### PR TITLE
added an interrupt check statement on for loops so that we can break …

### DIFF
--- a/vm/env.go
+++ b/vm/env.go
@@ -65,6 +65,18 @@ func (e *Env) NewPackage(n string) *Env {
 	}
 }
 
+// catchInterrupt checks if the interrupt was set
+// if the interrupt was set, it is reset and true is returned
+func (e *Env) catchInterrupt() (caught bool) {
+	e.Lock()
+	if *(e.interrupt) {
+		*(e.interrupt) = false
+		caught = true
+	}
+	e.Unlock()
+	return
+}
+
 // Destroy deletes current scope.
 func (e *Env) Destroy() {
 	e.Lock()

--- a/vm/vmStmt.go
+++ b/vm/vmStmt.go
@@ -253,6 +253,9 @@ func RunSingleStmt(stmt ast.Stmt, env *Env) (reflect.Value, error) {
 			defer newenv.Destroy()
 
 			for {
+				if env.catchInterrupt() {
+					return NilValue, InterruptError
+				}
 				iv, ok := val.Recv()
 				if !ok {
 					break

--- a/vm/vmStmt.go
+++ b/vm/vmStmt.go
@@ -31,15 +31,9 @@ func Run(stmts []ast.Stmt, env *Env) (reflect.Value, error) {
 
 // RunSingleStmt executes one statement in the specified environment.
 func RunSingleStmt(stmt ast.Stmt, env *Env) (reflect.Value, error) {
-	env.Lock()
-	if *(env.interrupt) {
-		*(env.interrupt) = false
-		env.Unlock()
-
+	if env.catchInterrupt() {
 		return NilValue, InterruptError
 	}
-	env.Unlock()
-
 	switch stmt := stmt.(type) {
 	case *ast.ExprStmt:
 		rv, err := invokeExpr(stmt.Expr, env)
@@ -189,6 +183,9 @@ func RunSingleStmt(stmt ast.Stmt, env *Env) (reflect.Value, error) {
 		newenv := env.NewEnv()
 		defer newenv.Destroy()
 		for {
+			if env.catchInterrupt() {
+				return NilValue, InterruptError
+			}
 			if stmt.Expr != nil {
 				ev, ee := invokeExpr(stmt.Expr, newenv)
 				if ee != nil {


### PR DESCRIPTION
If a script consists of "for{}" its not possible to break out of that statement because the loop statement has no sub statements.  I abstracted out the interrupt check to its own call to make it a little cleaner and added the check on the interrupt into each iteration of a for loop.

Its an edge case, but if you are running user supplied scripts, its possible for the user to livelock the VM in a way that you can't interrupt out of. 