### PR TITLE
Adding another interrupt statement to catch bad forloops

### DIFF
--- a/vm/vmStmt.go
+++ b/vm/vmStmt.go
@@ -293,6 +293,9 @@ func RunSingleStmt(stmt ast.Stmt, env *Env) (reflect.Value, error) {
 			return NilValue, err
 		}
 		for {
+			if env.catchInterrupt() {
+				return NilValue, InterruptError
+			}
 			fb, err := invokeExpr(stmt.Expr2, newenv)
 			if err != nil {
 				return NilValue, err


### PR DESCRIPTION
Sorry, missed one.

the code
```
for i = 0; i < 10; i += 0 {} 
```
is also uninterruptible.  Added another interrupt catch to fix it