### PR TITLE
Implicit conversions in equality comparisons

### DIFF
--- a/vm/vm.go
+++ b/vm/vm.go
@@ -120,11 +120,34 @@ func equal(lhsV, rhsV reflect.Value) bool {
 	if !lhsV.IsValid() || !rhsV.IsValid() {
 		return true
 	}
+
+	// Compare a string and a number.
+	// This will attempt to convert the string to a float64,
+	// while leaving the other side alone. Code further down
+	// will handle cases where we compare (int == string), which
+	// becomes (int == float) after this step
+	if isNum(lhsV) && rhsV.Kind() == reflect.String {
+		rhsF, err := tryToFloat64(rhsV)
+		if err != nil {
+			// Couldn't convert RHS to a float, they can't be compared.
+			return false
+		}
+		rhsV = reflect.ValueOf(rhsF)
+	} else if lhsV.Kind() == reflect.String && isNum(rhsV) {
+		// if LHS is a float, e.g. "1.2", we need to set lhsV to a float64
+		lhsF, err := tryToFloat64(lhsV)
+		if err != nil {
+			return false
+		}
+		lhsV = reflect.ValueOf(lhsF)
+	}
+
 	if isNum(lhsV) && isNum(rhsV) {
 		if rhsV.Type().ConvertibleTo(lhsV.Type()) {
 			rhsV = rhsV.Convert(lhsV.Type())
 		}
 	}
+
 	// Try to compare bools to strings and numbers
 	if lhsV.Kind() == reflect.Bool || rhsV.Kind() == reflect.Bool {
 		lhsB, err := tryToBool(lhsV, false)

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -125,6 +125,19 @@ func equal(lhsV, rhsV reflect.Value) bool {
 			rhsV = rhsV.Convert(lhsV.Type())
 		}
 	}
+	// Try to compare bools to strings and numbers
+	if lhsV.Kind() == reflect.Bool || rhsV.Kind() == reflect.Bool {
+		lhsB, err := tryToBool(lhsV, false)
+		if err != nil {
+			return false
+		}
+		rhsB, err := tryToBool(rhsV, false)
+		if err != nil {
+			return false
+		}
+		return lhsB == rhsB
+	}
+
 	if lhsV.CanInterface() && rhsV.CanInterface() {
 		return reflect.DeepEqual(lhsV.Interface(), rhsV.Interface())
 	}

--- a/vm/vmToX.go
+++ b/vm/vmToX.go
@@ -26,6 +26,13 @@ func toString(v reflect.Value) string {
 	return fmt.Sprint(v.Interface())
 }
 
+// tryToBool attempts to convert the value 'v' to a boolean, returning
+// an error if it cannot. When converting a string, the function returns
+// true if the string is the word "true", false if the string is "false",
+// and returns false & an error if it is any other string.
+// The 'caseSensitive' flag affects the behavior when converting strings;
+// if set to true, the function only matches on "true" or "false", not
+// e.g. "True" or "FALSE"
 func tryToBool(v reflect.Value, caseSensitive bool) (bool, error) {
 	if v.Kind() == reflect.Interface {
 		v = v.Elem()
@@ -64,28 +71,49 @@ func toBool(v reflect.Value) bool {
 
 // toFloat64 converts all reflect.Value-s into float64.
 func toFloat64(v reflect.Value) float64 {
+	f, _ := tryToFloat64(v)
+	return f
+}
+
+// tryToFloat64 attempts to convert a value to a float64.
+// If it cannot (in the case of a non-numeric string, a struct, etc.)
+// it returns 0.0 and an error.
+func tryToFloat64(v reflect.Value) (float64, error) {
 	if v.Kind() == reflect.Interface {
 		v = v.Elem()
 	}
 	switch v.Kind() {
 	case reflect.Float32, reflect.Float64:
-		return v.Float()
+		return v.Float(), nil
 	case reflect.Int, reflect.Int32, reflect.Int64:
-		return float64(v.Int())
+		return float64(v.Int()), nil
+	case reflect.String:
+		f, err := strconv.ParseFloat(v.String(), 64)
+		if err == nil {
+			return f, nil
+		}
 	}
-	return 0.0
+	return 0.0, errors.New("couldn't convert to a float64")
 }
 
 // toInt64 converts all reflect.Value-s into int64.
 func toInt64(v reflect.Value) int64 {
+	i, _ := tryToInt64(v)
+	return i
+}
+
+// tryToInt64 attempts to convert a value to an int64.
+// If it cannot (in the case of a non-numeric string, a struct, etc.)
+// it returns 0 and an error.
+func tryToInt64(v reflect.Value) (int64, error) {
 	if v.Kind() == reflect.Interface {
 		v = v.Elem()
 	}
 	switch v.Kind() {
 	case reflect.Float32, reflect.Float64:
-		return int64(v.Float())
+		return int64(v.Float()), nil
 	case reflect.Int, reflect.Int32, reflect.Int64:
-		return v.Int()
+		return v.Int(), nil
 	case reflect.String:
 		s := v.String()
 		var i int64
@@ -96,8 +124,14 @@ func toInt64(v reflect.Value) int64 {
 			i, err = strconv.ParseInt(s, 10, 64)
 		}
 		if err == nil {
-			return int64(i)
+			return int64(i), nil
+		}
+		// If ParseInt failed, it's possible the string is actually a float
+		// We convert floats to ints above, so let's do that here too
+		f, err := strconv.ParseFloat(s, 64)
+		if err == nil {
+			return int64(f), nil
 		}
 	}
-	return 0
+	return 0, errors.New("couldn't convert to integer")
 }

--- a/vm/vmToX.go
+++ b/vm/vmToX.go
@@ -126,12 +126,6 @@ func tryToInt64(v reflect.Value) (int64, error) {
 		if err == nil {
 			return int64(i), nil
 		}
-		// If ParseInt failed, it's possible the string is actually a float
-		// We convert floats to ints above, so let's do that here too
-		f, err := strconv.ParseFloat(s, 64)
-		if err == nil {
-			return int64(f), nil
-		}
 	}
 	return 0, errors.New("couldn't convert to integer")
 }

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -222,6 +222,17 @@ func TestComparisonOperators(t *testing.T) {
 		{script: `false == "False"`, runOutput: true},
 		{script: `false == "true"`, runOutput: false},
 		{script: `false == "foo"`, runOutput: false},
+
+		{script: `0 == "0"`, runOutput: true},
+		{script: `"1.0" == 1`, runOutput: true},
+		{script: `1 == "1"`, runOutput: true},
+		{script: `0.0 == "0"`, runOutput: true},
+		{script: `0.0 == "0.0"`, runOutput: true},
+		{script: `1.0 == "1.0"`, runOutput: true},
+		{script: `1.2 == "1.2"`, runOutput: true},
+		{script: `1.2 == "1"`, runOutput: false},
+		{script: `"1.1" == 1`, runOutput: false},
+		{script: `0 == "1"`, runOutput: false},
 	}
 	runTests(t, tests)
 }

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -230,6 +230,7 @@ func TestComparisonOperators(t *testing.T) {
 		{script: `0.0 == "0.0"`, runOutput: true},
 		{script: `1.0 == "1.0"`, runOutput: true},
 		{script: `1.2 == "1.2"`, runOutput: true},
+		{script: `"7" == 7.2`, runOutput: true},
 		{script: `1.2 == "1"`, runOutput: false},
 		{script: `"1.1" == 1`, runOutput: false},
 		{script: `0 == "1"`, runOutput: false},

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -211,6 +211,17 @@ func TestComparisonOperators(t *testing.T) {
 		{script: "1 == 1 || 1  == 2", runOutput: true},
 		{script: "1 == 2 || 1  == 1", runOutput: true},
 		{script: "1 == 2 || 1  == 2", runOutput: false},
+
+		{script: `true == "true"`, runOutput: true},
+		{script: `true == "TRUE"`, runOutput: true},
+		{script: `true == "True"`, runOutput: true},
+		{script: `true == "false"`, runOutput: false},
+		{script: `true == "foo"`, runOutput: false},
+		{script: `false == "false"`, runOutput: true},
+		{script: `false == "FALSE"`, runOutput: true},
+		{script: `false == "False"`, runOutput: true},
+		{script: `false == "true"`, runOutput: false},
+		{script: `false == "foo"`, runOutput: false},
 	}
 	runTests(t, tests)
 }


### PR DESCRIPTION
This is already sort-of implemented for >, <, >=, <=, and the arithmetic operations, but this adds the capability to evaluate things like:

"1.0" == 1 (evaluates to true)
1.1 == "1.0" (evaluates to false)
"7" == 7.2 (evaluates to true, "7" is an integer so we cast int(7.2) -> 7)