### PR TITLE
Formatting changes parser.go & added tests for opt terms

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -171,7 +171,7 @@ const yyEofCode = 1
 const yyErrCode = 2
 const yyInitialStackSize = 16
 
-//line parser.go.y:774
+//line parser.go.y:775
 
 //line yacctab:1
 var yyExca = [...]int{
@@ -2154,22 +2154,22 @@ yydefault:
 		}
 	case 134:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line parser.go.y:759
+		//line parser.go.y:761
 		{
 		}
 	case 135:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line parser.go.y:762
+		//line parser.go.y:764
 		{
 		}
 	case 136:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line parser.go.y:767
+		//line parser.go.y:769
 		{
 		}
 	case 137:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line parser.go.y:770
+		//line parser.go.y:772
 		{
 		}
 	}

--- a/parser/parser.go.y
+++ b/parser/parser.go.y
@@ -750,25 +750,26 @@ expr :
 		$$.SetPosition($1.Position())
 	}
 
-opt_terms : /* none */
+opt_terms : 
+	/* none */
 	| terms
 	;
 
 
-terms : term
+terms : 
+	term
 	{
 	}
 	| terms term
 	{
 	}
-	;
 
-term : ';'
+term :
+	';'
 	{
 	}
 	| '\n'
 	{
 	}
-	;
 
 %%

--- a/vm/vmOperators_test.go
+++ b/vm/vmOperators_test.go
@@ -11,8 +11,11 @@ func TestBasicOperators(t *testing.T) {
 	os.Setenv("ANKO_DEBUG", "1")
 	testInput1 := map[string]interface{}{"b": func() {}}
 	tests := []testStruct{
-		{script: `]`, parseError: fmt.Errorf("syntax error"), runOutput: nil},
-		{script: `1 = 2`, runError: fmt.Errorf("Invalid operation"), runOutput: nil},
+		{script: `]`, parseError: fmt.Errorf("syntax error")},
+		{script: `1 = 2`, runError: fmt.Errorf("Invalid operation")},
+		// TOFIX:
+		{script: `,b = 1, 2`, runOutput: int64(2)},
+		{script: `a, b = ,2`, runOutput: int64(2)},
 
 		{script: `2 + 1`, runOutput: int64(3)},
 		{script: `2 - 1`, runOutput: int64(1)},

--- a/vm/vmReturnsAndFunctions_test.go
+++ b/vm/vmReturnsAndFunctions_test.go
@@ -168,6 +168,7 @@ func TestFunctions(t *testing.T) {
 		{script: `a = [true]; a()`, runError: fmt.Errorf("cannot call type []interface {}")},
 		{script: `a = [true]; func b(c) { return c() }; b(a)`, runError: fmt.Errorf("cannot call type []interface {}")},
 		{script: `a = {}; a.missing()`, runError: fmt.Errorf("cannot call type interface {}"), output: map[string]interface{}{"a": map[string]interface{}{}}},
+		{script: `a = 1; b = func(,a){}; a`, parseError: fmt.Errorf("syntax error: unexpected ','"), runOutput: int64(1)},
 
 		{script: `func a(b) { }; a()`, runError: fmt.Errorf("function wants 1 arguments but received 0")},
 		{script: `func a(b) { }; a(true, true)`, runError: fmt.Errorf("function wants 1 arguments but received 2")},


### PR DESCRIPTION
Should the following be parser errors?
```
,b = 1, 2
a, b = ,2
```