### PR TITLE
Add LenExpr to the ast walker

### DIFF
--- a/ast/util/walk.go
+++ b/ast/util/walk.go
@@ -144,6 +144,7 @@ func walkExpr(expr ast.Expr, f WalkFunc) error {
 		return err
 	}
 	switch expr := expr.(type) {
+	case *ast.LenExpr:
 	case *ast.NumberExpr:
 	case *ast.IdentExpr:
 	case *ast.MemberExpr:

--- a/ast/util/walk_test.go
+++ b/ast/util/walk_test.go
@@ -37,6 +37,7 @@ func TestWalk(t *testing.T) {
 		t.Fatal(err)
 	}
 	var mainFound bool
+	var lenFound bool
 	err = Walk(stmts, func(e interface{}) error {
 		switch exp := e.(type) {
 		case *ast.CallExpr:
@@ -60,6 +61,8 @@ func TestWalk(t *testing.T) {
 			} else if mainFound && exp.Name == `Main` {
 				return errors.New("Main redefined")
 			}
+		case *ast.LenExpr:
+			lenFound = true
 		}
 		return nil
 	})
@@ -68,6 +71,9 @@ func TestWalk(t *testing.T) {
 	}
 	if !mainFound {
 		t.Fatal("Main not found")
+	}
+	if !lenFound {
+		t.Fatal("len not found")
 	}
 }
 

--- a/ast/util/walk_test.go
+++ b/ast/util/walk_test.go
@@ -24,6 +24,10 @@ func Main(arg1) {
 func Tester() {
 	return "YES"
 }
+
+func testLen() {
+	return len("test")
+}
 `
 )
 


### PR DESCRIPTION
walkExpr gets confused now that len() is part of the language itself instead of a builtin; this fixes the problem.