### PR TITLE
Add context so we can interrupt channels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 
 go:
-  - 1.6.x
   - 1.7.x
   - 1.8.x
   - 1.9.x

--- a/vm/env.go
+++ b/vm/env.go
@@ -20,12 +20,11 @@ type EnvResolver interface {
 // Env provides interface to run VM. This mean function scope and blocked-scope.
 // If stack goes to blocked-scope, it will make new Env.
 type Env struct {
-	name      string
-	env       map[string]reflect.Value
-	typ       map[string]reflect.Type
-	parent    *Env
-	interrupt *bool
-	external  EnvResolver
+	name     string
+	env      map[string]reflect.Value
+	typ      map[string]reflect.Type
+	parent   *Env
+	external EnvResolver
 	sync.RWMutex
 }
 
@@ -58,48 +57,40 @@ func newBasicTypes() map[string]reflect.Type {
 
 // NewEnv creates new global scope.
 func NewEnv() *Env {
-	b := false
-
 	return &Env{
-		env:       make(map[string]reflect.Value),
-		typ:       newBasicTypes(),
-		parent:    nil,
-		interrupt: &b,
+		env:    make(map[string]reflect.Value),
+		typ:    newBasicTypes(),
+		parent: nil,
 	}
 }
 
 // NewEnv creates new child scope.
 func (e *Env) NewEnv() *Env {
 	return &Env{
-		env:       make(map[string]reflect.Value),
-		typ:       make(map[string]reflect.Type),
-		parent:    e,
-		name:      e.name,
-		interrupt: e.interrupt,
+		env:    make(map[string]reflect.Value),
+		typ:    make(map[string]reflect.Type),
+		parent: e,
+		name:   e.name,
 	}
 }
 
 // NewPackage creates a new env with a name
 func NewPackage(n string) *Env {
-	b := false
-
 	return &Env{
-		env:       make(map[string]reflect.Value),
-		typ:       make(map[string]reflect.Type),
-		parent:    nil,
-		name:      n,
-		interrupt: &b,
+		env:    make(map[string]reflect.Value),
+		typ:    make(map[string]reflect.Type),
+		parent: nil,
+		name:   n,
 	}
 }
 
 // NewPackage creates a new env with a name under the parent env
 func (e *Env) NewPackage(n string) *Env {
 	return &Env{
-		env:       make(map[string]reflect.Value),
-		typ:       make(map[string]reflect.Type),
-		parent:    e,
-		name:      n,
-		interrupt: e.interrupt,
+		env:    make(map[string]reflect.Value),
+		typ:    make(map[string]reflect.Type),
+		parent: e,
+		name:   n,
 	}
 }
 
@@ -137,10 +128,9 @@ func (e *Env) SetExternal(res EnvResolver) {
 // NewModule creates new module scope as global.
 func (e *Env) NewModule(n string) *Env {
 	m := &Env{
-		env:       make(map[string]reflect.Value),
-		parent:    e,
-		name:      n,
-		interrupt: e.interrupt,
+		env:    make(map[string]reflect.Value),
+		parent: e,
+		name:   n,
 	}
 	e.Define(n, m)
 	return m
@@ -422,14 +412,12 @@ func (e *Env) RunContext(stmts []ast.Stmt, ctx context.Context) (interface{}, er
 func (e *Env) Copy() *Env {
 	e.Lock()
 	defer e.Unlock()
-	b := false
 	copy := Env{
-		name:      e.name,
-		env:       make(map[string]reflect.Value),
-		typ:       make(map[string]reflect.Type),
-		parent:    e.parent,
-		interrupt: &b,
-		external:  e.external,
+		name:     e.name,
+		env:      make(map[string]reflect.Value),
+		typ:      make(map[string]reflect.Type),
+		parent:   e.parent,
+		external: e.external,
 	}
 	for name, value := range e.env {
 		copy.env[name] = value

--- a/vm/env.go
+++ b/vm/env.go
@@ -1,6 +1,7 @@
 package vm
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"strings"
@@ -395,16 +396,26 @@ func (e *Env) Dump() {
 
 // Execute parses and runs source in current scope.
 func (e *Env) Execute(src string) (interface{}, error) {
+	return e.ExecuteContext(src, context.Background())
+}
+
+// Execute parses and runs source in current scope.
+func (e *Env) ExecuteContext(src string, ctx context.Context) (interface{}, error) {
 	stmts, err := parser.ParseSrc(src)
 	if err != nil {
 		return nilValue, err
 	}
-	return Run(stmts, e)
+	return RunContext(stmts, e, ctx)
 }
 
 // Run runs statements in current scope.
 func (e *Env) Run(stmts []ast.Stmt) (interface{}, error) {
-	return Run(stmts, e)
+	return RunContext(stmts, e, context.Background())
+}
+
+// Run runs statements in current scope.
+func (e *Env) RunContext(stmts []ast.Stmt, ctx context.Context) (interface{}, error) {
+	return RunContext(stmts, e, ctx)
 }
 
 // Copy the state of the virtual machine environment

--- a/vm/env.go
+++ b/vm/env.go
@@ -400,7 +400,7 @@ func (e *Env) ExecuteContext(src string, ctx context.Context) (interface{}, erro
 
 // Run runs statements in current scope.
 func (e *Env) Run(stmts []ast.Stmt) (interface{}, error) {
-	return RunContext(stmts, e, context.Background())
+	return e.RunContext(stmts, context.Background())
 }
 
 // Run runs statements in current scope.

--- a/vm/example_test.go
+++ b/vm/example_test.go
@@ -1,6 +1,7 @@
 package vm_test
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"sync"
@@ -35,15 +36,16 @@ for i = 0; i < 10000; i++ {
 println("this line should not be printed")
 `
 
+	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
 		close(waitChan)
-		v, err := env.Execute(script)
+		v, err := env.ExecuteContext(script, ctx)
 		fmt.Println(v, err)
 		waitGroup.Done()
 	}()
 
 	<-waitChan
-	vm.Interrupt(env)
+	cancel()
 
 	waitGroup.Wait()
 

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -81,25 +81,6 @@ func (e *Error) Error() string {
 	return e.Message
 }
 
-// Interrupt interrupts the execution of any running statements in the specified environment.
-// This includes all parent & child environments.
-// Note that the execution is not instantly aborted: after a call to Interrupt,
-// the current running statement will finish, but the next statement will not run,
-// and instead will return a nilValue and an ErrInterrupt.
-func Interrupt(env *Env) {
-	env.Lock()
-	*(env.interrupt) = true
-	env.Unlock()
-}
-
-// ClearInterrupt removes the interrupt flag from specified environment.
-// This includes all parent & child environments.
-func ClearInterrupt(env *Env) {
-	env.Lock()
-	*(env.interrupt) = false
-	env.Unlock()
-}
-
 func isNil(v reflect.Value) bool {
 	if !v.IsValid() {
 		return false

--- a/vm/vmExpr.go
+++ b/vm/vmExpr.go
@@ -710,11 +710,11 @@ func invokeExpr(expr ast.Expr, env *Env, ctx context.Context) (reflect.Value, er
 				cases := []reflect.SelectCase{{
 					Dir:  reflect.SelectRecv,
 					Chan: reflect.ValueOf(ctx.Done()),
-					Send: reflect.ValueOf(nil),
+					Send: zeroValue,
 				}, {
 					Dir:  reflect.SelectRecv,
 					Chan: rhs,
-					Send: reflect.ValueOf(nil),
+					Send: zeroValue,
 				}}
 				chosen, rv, _ := reflect.Select(cases)
 				if chosen == 0 {
@@ -739,7 +739,7 @@ func invokeExpr(expr ast.Expr, env *Env, ctx context.Context) (reflect.Value, er
 					cases := []reflect.SelectCase{{
 						Dir:  reflect.SelectRecv,
 						Chan: reflect.ValueOf(ctx.Done()),
-						Send: reflect.ValueOf(nil),
+						Send: zeroValue,
 					}, {
 						Dir:  reflect.SelectSend,
 						Chan: lhs,
@@ -754,11 +754,11 @@ func invokeExpr(expr ast.Expr, env *Env, ctx context.Context) (reflect.Value, er
 				cases := []reflect.SelectCase{{
 					Dir:  reflect.SelectRecv,
 					Chan: reflect.ValueOf(ctx.Done()),
-					Send: reflect.ValueOf(nil),
+					Send: zeroValue,
 				}, {
 					Dir:  reflect.SelectRecv,
 					Chan: rhs,
-					Send: reflect.ValueOf(nil),
+					Send: zeroValue,
 				}}
 				chosen, rv, ok := reflect.Select(cases)
 				if chosen == 0 {

--- a/vm/vmExpr.go
+++ b/vm/vmExpr.go
@@ -707,7 +707,6 @@ func invokeExpr(expr ast.Expr, env *Env, ctx context.Context) (reflect.Value, er
 
 		if e.Lhs == nil {
 			if rhs.Kind() == reflect.Chan {
-				var rv reflect.Value
 				cases := []reflect.SelectCase{{
 					Dir:  reflect.SelectRecv,
 					Chan: reflect.ValueOf(ctx.Done()),
@@ -717,8 +716,7 @@ func invokeExpr(expr ast.Expr, env *Env, ctx context.Context) (reflect.Value, er
 					Chan: rhs,
 					Send: reflect.ValueOf(nil),
 				}}
-				var chosen int
-				chosen, rv, _ = reflect.Select(cases)
+				chosen, rv, _ := reflect.Select(cases)
 				if chosen == 0 {
 					return nilValue, ErrInterrupt
 				}
@@ -742,8 +740,6 @@ func invokeExpr(expr ast.Expr, env *Env, ctx context.Context) (reflect.Value, er
 				}
 				return nilValue, nil
 			} else if rhs.Kind() == reflect.Chan {
-				var rv reflect.Value
-				var ok bool
 				cases := []reflect.SelectCase{{
 					Dir:  reflect.SelectRecv,
 					Chan: reflect.ValueOf(ctx.Done()),
@@ -753,8 +749,7 @@ func invokeExpr(expr ast.Expr, env *Env, ctx context.Context) (reflect.Value, er
 					Chan: rhs,
 					Send: reflect.ValueOf(nil),
 				}}
-				var chosen int
-				chosen, rv, ok = reflect.Select(cases)
+				chosen, rv, ok := reflect.Select(cases)
 				if chosen == 0 {
 					return nilValue, ErrInterrupt
 				}

--- a/vm/vmOperators_test.go
+++ b/vm/vmOperators_test.go
@@ -735,6 +735,8 @@ func TestForLoop(t *testing.T) {
 
 		{Script: `a = {"x": 2}; b = 0; for k, v in a { b = k }; b`, RunOutput: "x", Output: map[string]interface{}{"a": map[interface{}]interface{}{"x": int64(2)}, "b": "x"}},
 		{Script: `a = {"x": 2}; b = 0; for k, v in a { b = v }; b`, RunOutput: int64(2), Output: map[string]interface{}{"a": map[interface{}]interface{}{"x": int64(2)}, "b": int64(2)}},
+
+		{Script: `a = make(chan int64, 1); a <- 1; v = 0; for val in a { v = val; break; }; v`, RunOutput: int64(1), Output: map[string]interface{}{"v": int64(1)}},
 	}
 	testlib.Run(t, tests, nil)
 }

--- a/vm/vmStmt.go
+++ b/vm/vmStmt.go
@@ -364,8 +364,6 @@ func runSingleStmt(stmt ast.Stmt, env *Env, ctx context.Context) (reflect.Value,
 			newenv := env.NewEnv()
 
 			for {
-				var iv reflect.Value
-				var ok bool
 				cases := []reflect.SelectCase{{
 					Dir:  reflect.SelectRecv,
 					Chan: reflect.ValueOf(ctx.Done()),
@@ -375,8 +373,7 @@ func runSingleStmt(stmt ast.Stmt, env *Env, ctx context.Context) (reflect.Value,
 					Chan: val,
 					Send: reflect.ValueOf(nil),
 				}}
-				var chosen int
-				chosen, iv, ok = reflect.Select(cases)
+				chosen, iv, ok := reflect.Select(cases)
 				if chosen == 0 {
 					return nilValue, ErrInterrupt
 				}

--- a/vm/vmStmt.go
+++ b/vm/vmStmt.go
@@ -72,9 +72,6 @@ func RunSingleStmtContext(stmt ast.Stmt, env *Env, ctx context.Context) (interfa
 
 // runSingleStmt executes one statement in the specified environment.
 func runSingleStmt(stmt ast.Stmt, env *Env, ctx context.Context) (reflect.Value, error) {
-	if *(env.interrupt) {
-		return nilValue, ErrInterrupt
-	}
 	select {
 	case <-ctx.Done():
 		return nilValue, ErrInterrupt
@@ -278,9 +275,6 @@ func runSingleStmt(stmt ast.Stmt, env *Env, ctx context.Context) (reflect.Value,
 	case *ast.LoopStmt:
 		newenv := env.NewEnv()
 		for {
-			if *(env.interrupt) {
-				return nilValue, ErrInterrupt
-			}
 			select {
 			case <-ctx.Done():
 				return nilValue, ErrInterrupt
@@ -323,9 +317,6 @@ func runSingleStmt(stmt ast.Stmt, env *Env, ctx context.Context) (reflect.Value,
 			newenv := env.NewEnv()
 
 			for i := 0; i < val.Len(); i++ {
-				if *(env.interrupt) {
-					return nilValue, ErrInterrupt
-				}
 				select {
 				case <-ctx.Done():
 					return nilValue, ErrInterrupt
@@ -353,9 +344,6 @@ func runSingleStmt(stmt ast.Stmt, env *Env, ctx context.Context) (reflect.Value,
 
 			keys := val.MapKeys()
 			for i := 0; i < len(keys); i++ {
-				if *(env.interrupt) {
-					return nilValue, ErrInterrupt
-				}
 				select {
 				case <-ctx.Done():
 					return nilValue, ErrInterrupt
@@ -381,9 +369,6 @@ func runSingleStmt(stmt ast.Stmt, env *Env, ctx context.Context) (reflect.Value,
 			newenv := env.NewEnv()
 
 			for {
-				if *(env.interrupt) {
-					return nilValue, ErrInterrupt
-				}
 				select {
 				case <-ctx.Done():
 					return nilValue, ErrInterrupt
@@ -436,9 +421,6 @@ func runSingleStmt(stmt ast.Stmt, env *Env, ctx context.Context) (reflect.Value,
 			return nilValue, err
 		}
 		for {
-			if *(env.interrupt) {
-				return nilValue, ErrInterrupt
-			}
 			select {
 			case <-ctx.Done():
 				return nilValue, ErrInterrupt

--- a/vm/vmStmt.go
+++ b/vm/vmStmt.go
@@ -367,11 +367,11 @@ func runSingleStmt(stmt ast.Stmt, env *Env, ctx context.Context) (reflect.Value,
 				cases := []reflect.SelectCase{{
 					Dir:  reflect.SelectRecv,
 					Chan: reflect.ValueOf(ctx.Done()),
-					Send: reflect.ValueOf(nil),
+					Send: zeroValue,
 				}, {
 					Dir:  reflect.SelectRecv,
 					Chan: val,
-					Send: reflect.ValueOf(nil),
+					Send: zeroValue,
 				}}
 				chosen, iv, ok := reflect.Select(cases)
 				if chosen == 0 {

--- a/vm/vmStmt.go
+++ b/vm/vmStmt.go
@@ -1,6 +1,7 @@
 package vm
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 
@@ -9,7 +10,12 @@ import (
 
 // Run executes statements in the specified environment.
 func Run(stmts []ast.Stmt, env *Env) (interface{}, error) {
-	rv, err := run(stmts, env)
+	return RunContext(stmts, env, context.Background())
+}
+
+// Run executes statements in the specified environment.
+func RunContext(stmts []ast.Stmt, env *Env, ctx context.Context) (interface{}, error) {
+	rv, err := run(stmts, env, ctx)
 	if err == ErrReturn {
 		err = nil
 	}
@@ -20,25 +26,30 @@ func Run(stmts []ast.Stmt, env *Env) (interface{}, error) {
 }
 
 // run executes statements in the specified environment.
-func run(stmts []ast.Stmt, env *Env) (reflect.Value, error) {
+func run(stmts []ast.Stmt, env *Env, ctx context.Context) (reflect.Value, error) {
 	rv := nilValue
 	var err error
 	for _, stmt := range stmts {
-		switch stmt.(type) {
-		case *ast.BreakStmt:
-			return nilValue, ErrBreak
-		case *ast.ContinueStmt:
-			return nilValue, ErrContinue
-		case *ast.ReturnStmt:
-			rv, err = runSingleStmt(stmt, env)
-			if err != nil {
-				return rv, err
-			}
-			return rv, ErrReturn
+		select {
+		case <-ctx.Done():
+			return rv, ErrInterrupt
 		default:
-			rv, err = runSingleStmt(stmt, env)
-			if err != nil {
-				return rv, err
+			switch stmt.(type) {
+			case *ast.BreakStmt:
+				return nilValue, ErrBreak
+			case *ast.ContinueStmt:
+				return nilValue, ErrContinue
+			case *ast.ReturnStmt:
+				rv, err = runSingleStmt(stmt, env, ctx)
+				if err != nil {
+					return rv, err
+				}
+				return rv, ErrReturn
+			default:
+				rv, err = runSingleStmt(stmt, env, ctx)
+				if err != nil {
+					return rv, err
+				}
 			}
 		}
 	}
@@ -47,7 +58,12 @@ func run(stmts []ast.Stmt, env *Env) (reflect.Value, error) {
 
 // RunSingleStmt executes one statement in the specified environment.
 func RunSingleStmt(stmt ast.Stmt, env *Env) (interface{}, error) {
-	rv, err := runSingleStmt(stmt, env)
+	return RunSingleStmtContext(stmt, env, context.Background())
+}
+
+// RunSingleStmt executes one statement in the specified environment.
+func RunSingleStmtContext(stmt ast.Stmt, env *Env, ctx context.Context) (interface{}, error) {
+	rv, err := runSingleStmt(stmt, env, ctx)
 	if !rv.IsValid() || !rv.CanInterface() {
 		return nil, err
 	}
@@ -55,15 +71,20 @@ func RunSingleStmt(stmt ast.Stmt, env *Env) (interface{}, error) {
 }
 
 // runSingleStmt executes one statement in the specified environment.
-func runSingleStmt(stmt ast.Stmt, env *Env) (reflect.Value, error) {
+func runSingleStmt(stmt ast.Stmt, env *Env, ctx context.Context) (reflect.Value, error) {
 	if *(env.interrupt) {
 		return nilValue, ErrInterrupt
+	}
+	select {
+	case <-ctx.Done():
+		return nilValue, ErrInterrupt
+	default:
 	}
 	switch stmt := stmt.(type) {
 
 	// ExprStmt
 	case *ast.ExprStmt:
-		rv, err := invokeExpr(stmt.Expr, env)
+		rv, err := invokeExpr(stmt.Expr, env, ctx)
 		if err != nil {
 			return rv, newError(stmt.Expr, err)
 		}
@@ -76,7 +97,7 @@ func runSingleStmt(stmt ast.Stmt, env *Env) (reflect.Value, error) {
 		// get right side expression values
 		rvs := make([]reflect.Value, len(stmt.Exprs))
 		for i, expr := range stmt.Exprs {
-			rvs[i], err = invokeExpr(expr, env)
+			rvs[i], err = invokeExpr(expr, env, ctx)
 			if err != nil {
 				return nilValue, newError(expr, err)
 			}
@@ -113,7 +134,7 @@ func runSingleStmt(stmt ast.Stmt, env *Env) (reflect.Value, error) {
 		// get right side expression values
 		rvs := make([]reflect.Value, len(stmt.Rhss))
 		for i, rhs := range stmt.Rhss {
-			rvs[i], err = invokeExpr(rhs, env)
+			rvs[i], err = invokeExpr(rhs, env, ctx)
 			if err != nil {
 				return nilValue, newError(rhs, err)
 			}
@@ -128,7 +149,7 @@ func runSingleStmt(stmt ast.Stmt, env *Env) (reflect.Value, error) {
 			if (value.Kind() == reflect.Slice || value.Kind() == reflect.Array) && value.Len() > 0 {
 				// value is slice/array, add each value to left side expression
 				for i := 0; i < value.Len() && i < len(stmt.Lhss); i++ {
-					_, err = invokeLetExpr(stmt.Lhss[i], value.Index(i), env)
+					_, err = invokeLetExpr(stmt.Lhss[i], value.Index(i), env, ctx)
 					if err != nil {
 						return nilValue, newError(stmt.Lhss[i], err)
 					}
@@ -144,7 +165,7 @@ func runSingleStmt(stmt ast.Stmt, env *Env) (reflect.Value, error) {
 			if value.Kind() == reflect.Interface && !value.IsNil() {
 				value = value.Elem()
 			}
-			_, err = invokeLetExpr(stmt.Lhss[i], value, env)
+			_, err = invokeLetExpr(stmt.Lhss[i], value, env, ctx)
 			if err != nil {
 				return nilValue, newError(stmt.Lhss[i], err)
 			}
@@ -155,7 +176,7 @@ func runSingleStmt(stmt ast.Stmt, env *Env) (reflect.Value, error) {
 
 	// LetMapItemStmt
 	case *ast.LetMapItemStmt:
-		rv, err := invokeExpr(stmt.Rhs, env)
+		rv, err := invokeExpr(stmt.Rhs, env, ctx)
 		if err != nil {
 			return nilValue, newError(stmt, err)
 		}
@@ -170,7 +191,7 @@ func runSingleStmt(stmt ast.Stmt, env *Env) (reflect.Value, error) {
 			if v.Kind() == reflect.Interface && !v.IsNil() {
 				v = v.Elem()
 			}
-			_, err = invokeLetExpr(lhs, v, env)
+			_, err = invokeLetExpr(lhs, v, env, ctx)
 			if err != nil {
 				return nilValue, newError(lhs, err)
 			}
@@ -180,7 +201,7 @@ func runSingleStmt(stmt ast.Stmt, env *Env) (reflect.Value, error) {
 	// IfStmt
 	case *ast.IfStmt:
 		// if
-		rv, err := invokeExpr(stmt.If, env)
+		rv, err := invokeExpr(stmt.If, env, ctx)
 		if err != nil {
 			return rv, newError(stmt.If, err)
 		}
@@ -188,7 +209,7 @@ func runSingleStmt(stmt ast.Stmt, env *Env) (reflect.Value, error) {
 		if toBool(rv) {
 			// then
 			newenv := env.NewEnv()
-			rv, err = run(stmt.Then, newenv)
+			rv, err = run(stmt.Then, newenv, ctx)
 			if err != nil {
 				return rv, newError(stmt, err)
 			}
@@ -199,7 +220,7 @@ func runSingleStmt(stmt ast.Stmt, env *Env) (reflect.Value, error) {
 			elseIf := statement.(*ast.IfStmt)
 			// else if - if
 			newenv := env.NewEnv()
-			rv, err = invokeExpr(elseIf.If, newenv)
+			rv, err = invokeExpr(elseIf.If, newenv, ctx)
 			if err != nil {
 				return rv, newError(elseIf.If, err)
 			}
@@ -209,7 +230,7 @@ func runSingleStmt(stmt ast.Stmt, env *Env) (reflect.Value, error) {
 
 			// else if - then
 			newenv = env.NewEnv()
-			rv, err = run(elseIf.Then, newenv)
+			rv, err = run(elseIf.Then, newenv, ctx)
 			if err != nil {
 				return rv, newError(elseIf, err)
 			}
@@ -219,7 +240,7 @@ func runSingleStmt(stmt ast.Stmt, env *Env) (reflect.Value, error) {
 		if len(stmt.Else) > 0 {
 			// else
 			newenv := env.NewEnv()
-			rv, err = run(stmt.Else, newenv)
+			rv, err = run(stmt.Else, newenv, ctx)
 			if err != nil {
 				return rv, newError(stmt, err)
 			}
@@ -230,14 +251,14 @@ func runSingleStmt(stmt ast.Stmt, env *Env) (reflect.Value, error) {
 	// TryStmt
 	case *ast.TryStmt:
 		newenv := env.NewEnv()
-		_, err := run(stmt.Try, newenv)
+		_, err := run(stmt.Try, newenv, ctx)
 		if err != nil {
 			// Catch
 			cenv := env.NewEnv()
 			if stmt.Var != "" {
 				cenv.defineValue(stmt.Var, reflect.ValueOf(err))
 			}
-			_, e1 := run(stmt.Catch, cenv)
+			_, e1 := run(stmt.Catch, cenv, ctx)
 			if e1 != nil {
 				err = newError(stmt.Catch[0], e1)
 			} else {
@@ -246,7 +267,7 @@ func runSingleStmt(stmt ast.Stmt, env *Env) (reflect.Value, error) {
 		}
 		if len(stmt.Finally) > 0 {
 			// Finally
-			_, e2 := run(stmt.Finally, newenv)
+			_, e2 := run(stmt.Finally, newenv, ctx)
 			if e2 != nil {
 				err = newError(stmt.Finally[0], e2)
 			}
@@ -260,8 +281,13 @@ func runSingleStmt(stmt ast.Stmt, env *Env) (reflect.Value, error) {
 			if *(env.interrupt) {
 				return nilValue, ErrInterrupt
 			}
+			select {
+			case <-ctx.Done():
+				return nilValue, ErrInterrupt
+			default:
+			}
 			if stmt.Expr != nil {
-				ev, ee := invokeExpr(stmt.Expr, newenv)
+				ev, ee := invokeExpr(stmt.Expr, newenv, ctx)
 				if ee != nil {
 					return ev, ee
 				}
@@ -270,7 +296,7 @@ func runSingleStmt(stmt ast.Stmt, env *Env) (reflect.Value, error) {
 				}
 			}
 
-			rv, err := run(stmt.Stmts, newenv)
+			rv, err := run(stmt.Stmts, newenv, ctx)
 			if err != nil && err != ErrContinue {
 				if err == ErrBreak {
 					break
@@ -285,7 +311,7 @@ func runSingleStmt(stmt ast.Stmt, env *Env) (reflect.Value, error) {
 
 	// ForStmt
 	case *ast.ForStmt:
-		val, ee := invokeExpr(stmt.Value, env)
+		val, ee := invokeExpr(stmt.Value, env, ctx)
 		if ee != nil {
 			return val, ee
 		}
@@ -300,12 +326,17 @@ func runSingleStmt(stmt ast.Stmt, env *Env) (reflect.Value, error) {
 				if *(env.interrupt) {
 					return nilValue, ErrInterrupt
 				}
+				select {
+				case <-ctx.Done():
+					return nilValue, ErrInterrupt
+				default:
+				}
 				iv := val.Index(i)
 				if iv.Kind() == reflect.Ptr || (iv.Kind() == reflect.Interface && !iv.IsNil()) {
 					iv = iv.Elem()
 				}
 				newenv.defineValue(stmt.Vars[0], iv)
-				rv, err := run(stmt.Stmts, newenv)
+				rv, err := run(stmt.Stmts, newenv, ctx)
 				if err != nil && err != ErrContinue {
 					if err == ErrBreak {
 						break
@@ -325,11 +356,16 @@ func runSingleStmt(stmt ast.Stmt, env *Env) (reflect.Value, error) {
 				if *(env.interrupt) {
 					return nilValue, ErrInterrupt
 				}
+				select {
+				case <-ctx.Done():
+					return nilValue, ErrInterrupt
+				default:
+				}
 				newenv.defineValue(stmt.Vars[0], keys[i])
 				if len(stmt.Vars) > 1 {
 					newenv.defineValue(stmt.Vars[1], val.MapIndex(keys[i]))
 				}
-				rv, err := run(stmt.Stmts, newenv)
+				rv, err := run(stmt.Stmts, newenv, ctx)
 				if err != nil && err != ErrContinue {
 					if err == ErrBreak {
 						break
@@ -348,7 +384,27 @@ func runSingleStmt(stmt ast.Stmt, env *Env) (reflect.Value, error) {
 				if *(env.interrupt) {
 					return nilValue, ErrInterrupt
 				}
-				iv, ok := val.Recv()
+				select {
+				case <-ctx.Done():
+					return nilValue, ErrInterrupt
+				default:
+				}
+				var iv reflect.Value
+				var ok bool
+				cases := []reflect.SelectCase{{
+					Dir:  reflect.SelectRecv,
+					Chan: reflect.ValueOf(ctx.Done()),
+					Send: reflect.ValueOf(nil),
+				}, {
+					Dir:  reflect.SelectRecv,
+					Chan: val,
+					Send: reflect.ValueOf(nil),
+				}}
+				var chosen int
+				chosen, iv, ok = reflect.Select(cases)
+				if chosen == 0 {
+					return nilValue, ErrInterrupt
+				}
 				if !ok {
 					break
 				}
@@ -356,7 +412,7 @@ func runSingleStmt(stmt ast.Stmt, env *Env) (reflect.Value, error) {
 					iv = iv.Elem()
 				}
 				newenv.defineValue(stmt.Vars[0], iv)
-				rv, err := run(stmt.Stmts, newenv)
+				rv, err := run(stmt.Stmts, newenv, ctx)
 				if err != nil && err != ErrContinue {
 					if err == ErrBreak {
 						break
@@ -375,7 +431,7 @@ func runSingleStmt(stmt ast.Stmt, env *Env) (reflect.Value, error) {
 	// CForStmt
 	case *ast.CForStmt:
 		newenv := env.NewEnv()
-		_, err := runSingleStmt(stmt.Stmt1, newenv)
+		_, err := runSingleStmt(stmt.Stmt1, newenv, ctx)
 		if err != nil {
 			return nilValue, err
 		}
@@ -383,7 +439,12 @@ func runSingleStmt(stmt ast.Stmt, env *Env) (reflect.Value, error) {
 			if *(env.interrupt) {
 				return nilValue, ErrInterrupt
 			}
-			fb, err := invokeExpr(stmt.Expr2, newenv)
+			select {
+			case <-ctx.Done():
+				return nilValue, ErrInterrupt
+			default:
+			}
+			fb, err := invokeExpr(stmt.Expr2, newenv, ctx)
 			if err != nil {
 				return nilValue, err
 			}
@@ -391,7 +452,7 @@ func runSingleStmt(stmt ast.Stmt, env *Env) (reflect.Value, error) {
 				break
 			}
 
-			rv, err := run(stmt.Stmts, newenv)
+			rv, err := run(stmt.Stmts, newenv, ctx)
 			if err != nil && err != ErrContinue {
 				if err == ErrBreak {
 					break
@@ -401,7 +462,7 @@ func runSingleStmt(stmt ast.Stmt, env *Env) (reflect.Value, error) {
 				}
 				return nilValue, newError(stmt, err)
 			}
-			_, err = invokeExpr(stmt.Expr3, newenv)
+			_, err = invokeExpr(stmt.Expr3, newenv, ctx)
 			if err != nil {
 				return nilValue, err
 			}
@@ -416,7 +477,7 @@ func runSingleStmt(stmt ast.Stmt, env *Env) (reflect.Value, error) {
 		case 0:
 			return rv, nil
 		case 1:
-			rv, err = invokeExpr(stmt.Exprs[0], env)
+			rv, err = invokeExpr(stmt.Exprs[0], env, ctx)
 			if err != nil {
 				return rv, newError(stmt, err)
 			}
@@ -424,7 +485,7 @@ func runSingleStmt(stmt ast.Stmt, env *Env) (reflect.Value, error) {
 		}
 		rvs := make([]interface{}, len(stmt.Exprs))
 		for i, expr := range stmt.Exprs {
-			rv, err = invokeExpr(expr, env)
+			rv, err = invokeExpr(expr, env, ctx)
 			if err != nil {
 				return rv, newError(stmt, err)
 			}
@@ -438,7 +499,7 @@ func runSingleStmt(stmt ast.Stmt, env *Env) (reflect.Value, error) {
 
 	// ThrowStmt
 	case *ast.ThrowStmt:
-		rv, err := invokeExpr(stmt.Expr, env)
+		rv, err := invokeExpr(stmt.Expr, env, ctx)
 		if err != nil {
 			return rv, newError(stmt, err)
 		}
@@ -451,7 +512,7 @@ func runSingleStmt(stmt ast.Stmt, env *Env) (reflect.Value, error) {
 	case *ast.ModuleStmt:
 		newenv := env.NewEnv()
 		newenv.SetName(stmt.Name)
-		rv, err := run(stmt.Stmts, newenv)
+		rv, err := run(stmt.Stmts, newenv, ctx)
 		if err != nil {
 			return rv, newError(stmt, err)
 		}
@@ -461,7 +522,7 @@ func runSingleStmt(stmt ast.Stmt, env *Env) (reflect.Value, error) {
 	// SwitchStmt
 	case *ast.SwitchStmt:
 		newenv := env.NewEnv()
-		rv, err := invokeExpr(stmt.Expr, newenv)
+		rv, err := invokeExpr(stmt.Expr, newenv, ctx)
 		if err != nil {
 			return rv, newError(stmt, err)
 		}
@@ -477,7 +538,7 @@ func runSingleStmt(stmt ast.Stmt, env *Env) (reflect.Value, error) {
 		for _, switchCaseStmt := range body.Cases {
 			caseStmt := switchCaseStmt.(*ast.SwitchCaseStmt)
 			for _, expr := range caseStmt.Exprs {
-				caseValue, err = invokeExpr(expr, newenv)
+				caseValue, err = invokeExpr(expr, newenv, ctx)
 				if err != nil {
 					return nilValue, newError(expr, err)
 				}
@@ -489,7 +550,7 @@ func runSingleStmt(stmt ast.Stmt, env *Env) (reflect.Value, error) {
 		}
 
 		if statements != nil {
-			rv, err = run(statements, newenv)
+			rv, err = run(statements, newenv, ctx)
 			if err != nil {
 				return rv, err
 			}
@@ -499,7 +560,7 @@ func runSingleStmt(stmt ast.Stmt, env *Env) (reflect.Value, error) {
 
 	// GoroutineStmt
 	case *ast.GoroutineStmt:
-		return invokeExpr(stmt.Expr, env)
+		return invokeExpr(stmt.Expr, env, ctx)
 
 	// default
 	default:

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -771,6 +771,11 @@ for {
 	a <-make(chan string)
 }
 `,
+		`
+a = make(chan int)
+closeWaitChan()
+a <- 1
+`,
 	}
 	for _, script := range scripts {
 		runCancelTestWithContext(t, script)

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -755,6 +755,22 @@ for i in a {
 	}
 }
 `,
+		`
+closeWaitChan()
+<-make(chan string)
+`,
+		`
+a = ""
+closeWaitChan()
+a <-make(chan string)
+`,
+		`
+for {
+	a = ""
+	closeWaitChan()
+	a <-make(chan string)
+}
+`,
 	}
 	for _, script := range scripts {
 		runCancelTestWithContext(t, script)
@@ -786,30 +802,6 @@ func runCancelTestWithContext(t *testing.T, script string) {
 	}()
 
 	_, err = env.ExecuteContext(script, ctx)
-	if err == nil || err.Error() != ErrInterrupt.Error() {
-		t.Errorf("execute error - received %#v - expected: %#v", err, ErrInterrupt)
-	}
-}
-
-func TestCancelChannelWithContext(t *testing.T) {
-	env := NewEnv()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	go func() {
-		time.Sleep(time.Millisecond)
-		cancel()
-	}()
-	_, err := env.ExecuteContext("<-make(chan string)", ctx)
-	if err == nil || err.Error() != ErrInterrupt.Error() {
-		t.Errorf("execute error - received %#v - expected: %#v", err, ErrInterrupt)
-	}
-
-	ctx, cancel = context.WithCancel(context.Background())
-	go func() {
-		time.Sleep(time.Millisecond)
-		cancel()
-	}()
-	_, err = env.ExecuteContext(`a = ""; a <-make(chan string)`, ctx)
 	if err == nil || err.Error() != ErrInterrupt.Error() {
 		t.Errorf("execute error - received %#v - expected: %#v", err, ErrInterrupt)
 	}

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"reflect"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -787,7 +786,7 @@ func runInterruptTestWithContext(t *testing.T, script string) {
 	}()
 
 	_, err = env.ExecuteContext(script, ctx)
-	if err == nil || !strings.Contains(err.Error(), ErrInterrupt.Error()) {
+	if err == nil || err.Error() != ErrInterrupt.Error() {
 		t.Errorf("execute error - received %#v - expected: %#v", err, ErrInterrupt)
 	}
 }
@@ -818,7 +817,7 @@ func TestInterruptChannelWithContext(t *testing.T) {
 	<-testDoneCh
 }
 
-func TestInterruptConcurrency(t *testing.T) {
+func TestContextConcurrency(t *testing.T) {
 	var waitGroup sync.WaitGroup
 	env := NewEnv()
 

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -674,7 +674,7 @@ func TestComment(t *testing.T) {
 	testlib.Run(t, tests, nil)
 }
 
-func TestInterrupts(t *testing.T) {
+func TestCancelWithContext(t *testing.T) {
 	scripts := []string{
 		`
 b = 0
@@ -757,11 +757,11 @@ for i in a {
 `,
 	}
 	for _, script := range scripts {
-		runInterruptTestWithContext(t, script)
+		runCancelTestWithContext(t, script)
 	}
 }
 
-func runInterruptTestWithContext(t *testing.T, script string) {
+func runCancelTestWithContext(t *testing.T, script string) {
 	waitChan := make(chan struct{}, 1)
 	closeWaitChan := func() {
 		close(waitChan)
@@ -791,7 +791,7 @@ func runInterruptTestWithContext(t *testing.T, script string) {
 	}
 }
 
-func TestInterruptChannelWithContext(t *testing.T) {
+func TestCancelChannelWithContext(t *testing.T) {
 	canCancelCh := make(chan struct{})
 	testDoneCh := make(chan struct{})
 

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -776,6 +776,11 @@ a = make(chan int)
 closeWaitChan()
 a <- 1
 `,
+		`
+a = make(chan interface)
+closeWaitChan()
+a <- nil
+`,
 	}
 	for _, script := range scripts {
 		runCancelTestWithContext(t, script)

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -781,6 +781,11 @@ a = make(chan interface)
 closeWaitChan()
 a <- nil
 `,
+		`
+a = make(chan int64, 1)
+closeWaitChan()
+for v in a { }
+`,
 	}
 	for _, script := range scripts {
 		runCancelTestWithContext(t, script)


### PR DESCRIPTION
**Problem:** When you have a script that ends with "receive from chan", the script get stuck there forever, and `vm.Interrupt(env)` is unable to cancel the execution of that script.
Example:
```
ch = make(chan string)
<-ch
```
**Solution:** I added an optional `(e *Env) SetContext(context.Context) *Env` function.
When you give a context to this function, it will change how it interrupt the code inside the VM.
There is 2 main differences
- The main loop will check for each statement if there is a context, and if it should exit the loop.
- The channels will now "select" between the `ctx.Done()` and the channel, instead of just waiting forever on the `ch.Recv()`

If there is no context, none of the above apply, the code execute as it was before.

The test [TestInterruptChannelWithContext](https://github.com/mattn/anko/pull/285/files#diff-d11f06e0aa37028f414640b3ea88c2acR827) will break the current master