### PR TITLE
strip comments before processing

### DIFF
--- a/anko.go
+++ b/anko.go
@@ -110,7 +110,9 @@ func main() {
 			}
 			code += string(b)
 		} else {
-			code = string(b)
+			for _, line := range strings.Split(code, "\n") {
+				code += strings.Split(line, "//")[0]
+			}
 		}
 
 		parser.EnableErrorVerbose()


### PR DESCRIPTION
This change strips comments from the source read from a file in non-interactive mode such that the comments do not cause the syntax check to fail.