### PR TITLE
 add option for panic capturing in Exec/Run

### DIFF
--- a/vm/env.go
+++ b/vm/env.go
@@ -3,6 +3,7 @@ package vm
 import (
 	"context"
 	"fmt"
+	"os"
 	"reflect"
 	"strings"
 	"sync"
@@ -381,11 +382,17 @@ func (e *Env) Execute(src string) (interface{}, error) {
 
 // ExecuteContext parses and runs source in current scope.
 func (e *Env) ExecuteContext(ctx context.Context, src string) (interface{}, error) {
+	return e.ExecuteContextUnsafe(context.Background(), src, os.Getenv("ANKO_DEBUG") == "")
+}
+
+// ExecuteContextUnsafe parses and runs source in current scope, with panics captured
+// or passed-through as specified.
+func (e *Env) ExecuteContextUnsafe(ctx context.Context, src string, capturePanic bool) (interface{}, error) {
 	stmt, err := parser.ParseSrc(src)
 	if err != nil {
 		return nilValue, err
 	}
-	return RunContext(ctx, stmt, e)
+	return RunContextUnsafe(ctx, stmt, e, capturePanic)
 }
 
 // Run runs statement in current scope.

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"reflect"
 
 	"github.com/mattn/anko/ast"
@@ -26,6 +25,9 @@ type (
 		stmt     ast.Stmt
 		expr     ast.Expr
 		operator ast.Operator
+
+		// options
+		capturePanic bool
 
 		// outgoing
 		rv  reflect.Value
@@ -309,9 +311,9 @@ func makeType(runInfo *runInfoStruct, typeStruct *ast.TypeStruct) reflect.Type {
 		if t == nil {
 			return nil
 		}
-		// capture panics if not in debug mode
+		// capture panics if opted to
 		defer func() {
-			if os.Getenv("ANKO_DEBUG") == "" {
+			if runInfo.capturePanic {
 				if recoverResult := recover(); recoverResult != nil {
 					runInfo.err = fmt.Errorf("%v", recoverResult)
 					t = nil

--- a/vm/vmExpr.go
+++ b/vm/vmExpr.go
@@ -2,7 +2,6 @@ package vm
 
 import (
 	"fmt"
-	"os"
 	"reflect"
 
 	"github.com/mattn/anko/ast"
@@ -645,9 +644,9 @@ func (runInfo *runInfoStruct) invokeExpr() {
 			Chan: runInfo.rv,
 			Send: rhs,
 		}}
-		// capture panics if not in debug mode
+		// capture panics if opted to
 		defer func() {
-			if os.Getenv("ANKO_DEBUG") == "" {
+			if runInfo.capturePanic {
 				if recoverResult := recover(); recoverResult != nil {
 					runInfo.err = fmt.Errorf("%v", recoverResult)
 				}

--- a/vm/vmExprFunction.go
+++ b/vm/vmExprFunction.go
@@ -3,7 +3,6 @@ package vm
 import (
 	"context"
 	"fmt"
-	"os"
 	"reflect"
 
 	"github.com/mattn/anko/ast"
@@ -140,9 +139,9 @@ func (runInfo *runInfoStruct) callExpr() {
 		return
 	}
 
-	// capture panics if not in debug mode
+	// capture panics if opted to
 	defer func() {
-		if os.Getenv("ANKO_DEBUG") == "" {
+		if runInfo.capturePanic {
 			if recoverResult := recover(); recoverResult != nil {
 				runInfo.err = fmt.Errorf("%v", recoverResult)
 				runInfo.rv = nilValue

--- a/vm/vmStmt.go
+++ b/vm/vmStmt.go
@@ -3,6 +3,7 @@ package vm
 import (
 	"context"
 	"fmt"
+	"os"
 	"reflect"
 
 	"github.com/mattn/anko/ast"
@@ -15,7 +16,13 @@ func Run(stmt ast.Stmt, env *Env) (interface{}, error) {
 
 // RunContext executes statement in the specified environment with context.
 func RunContext(ctx context.Context, stmt ast.Stmt, env *Env) (interface{}, error) {
-	runInfo := runInfoStruct{ctx: ctx, env: env, stmt: stmt, rv: nilValue}
+	return RunContextUnsafe(ctx, stmt, env, os.Getenv("ANKO_DEBUG") == "")
+}
+
+// RunContextUnsafe executes statement in the specified environment with context, with panics captured
+// or passed-through as specified.
+func RunContextUnsafe(ctx context.Context, stmt ast.Stmt, env *Env, capturePanic bool) (interface{}, error) {
+	runInfo := runInfoStruct{ctx: ctx, env: env, stmt: stmt, rv: nilValue, capturePanic: capturePanic}
 	runInfo.runSingleStmt()
 	if runInfo.err == ErrReturn {
 		runInfo.err = nil


### PR DESCRIPTION
In running scripts, Anko will capture panics unless run in debug mode. 

My case is that I wrote a framework, with some library functions meant to be called by application code, the applications are supposed to be written in part Go , part Anko script. And the framework accepts scripts from elsewhere, and run them with an Anko env. While the applications may be mis-using the library functions sometimes, in which case a library function will panic with error description. And since the scripts come from many where and executes with great concurrency, just the error description is far from adequate to locate which application and which part of it caused the error, full stack trace is much desired for trouble shooting few bugs among massive concurrent tasks running smoothly in a production system, where I can't put Anko in debug mode.

What I'm suggesting in this PR is that an `Unsafe` version of `ExecuteContext` and `RunContext` be added, with an option argument `capturePanic bool`, to specify whether the caller intends to capture panics from the script code by itself. And existing `ExecuteContext` and `RunContext` stay the same behavior wrt the ${ANKO_DEBUG} environment variable.

Another option may be to coerce whatever captured into `error` type for `runInfo.err` in more sophisticated ways, I would do that by a custom `errors` module in each of my Go projects, like:

```go
runInfo.err = errors.RichError(recoverResult)
```

```go
package errors

import (
	"fmt"

	"github.com/pkg/errors"
)

var (
	New    = errors.New
	Errorf = errors.Errorf
	Wrap   = errors.Wrap
	Wrapf  = errors.Wrapf
)

// github.com/pkg/errors can be formatted with rich information, including stacktrace, see:
// 	https://godoc.org/github.com/pkg/errors#hdr-Formatted_printing_of_errors
type richError interface {
	error
	fmt.Formatter
}

// wrap as necessary an object with rich (stacktrace esp.) information.
func RichError(err interface{}) error {
	if err == nil {
		return nil
	}
	switch err := err.(type) {
	case richError:
		return err
	case error:
		return errors.Wrap(err, err.Error()).(richError)
	default:
		return errors.New(fmt.Sprintf("%s", err)).(richError)
	}
}
```

But I think that's only a temporary solution before the std `errors` module provides richer info ultimately, so am not willing to persuade others to do alike.
