### PR TITLE
panic vm.Error instead of plain string

### DIFF
--- a/vm/vmConvertToX.go
+++ b/vm/vmConvertToX.go
@@ -162,7 +162,8 @@ func convertVMFunctionToType(rv reflect.Value, rt reflect.Type) (reflect.Value, 
 		rv, err := processCallReturnValues(rvs, true, false)
 		if err != nil {
 			if vmErr, ok := err.(*Error); ok {
-				panic(vmErr)
+				panic(fmt.Sprintf("function run error: %v - at line %d, column %d",
+					vmErr.Error(), vmErr.Pos.Line, vmErr.Pos.Column))
 			} else {
 				panic("function run error: " + err.Error())
 			}

--- a/vm/vmConvertToX.go
+++ b/vm/vmConvertToX.go
@@ -161,7 +161,11 @@ func convertVMFunctionToType(rv reflect.Value, rt reflect.Type) (reflect.Value, 
 		// returns normal VM reflect.Value form
 		rv, err := processCallReturnValues(rvs, true, false)
 		if err != nil {
-			panic("function run error: " + err.Error())
+			if vmErr, ok := err.(*Error); ok {
+				panic(vmErr)
+			} else {
+				panic("function run error: " + err.Error())
+			}
 		}
 
 		if rt.NumOut() < 1 {

--- a/vm/vmFunctions_test.go
+++ b/vm/vmFunctions_test.go
@@ -658,7 +658,7 @@ func TestFunctionConversions(t *testing.T) {
 		{Script: `b = func(){ return 1++ }; c = a(b)`,
 			Input: map[string]interface{}{"a": func(b func() bool) bool {
 				return b()
-			}}, RunError: fmt.Errorf("function run error: invalid operation")},
+			}}, RunError: fmt.Errorf("function run error: invalid operation - at line 1, column 5")},
 		{Script: `b = func(){ return true }; c = a(b)`,
 			Input: map[string]interface{}{"a": func(b func() string) string {
 				return b()

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -1170,18 +1170,12 @@ func TestReflectPanicOnUndefinedSymbol(t *testing.T) {
 	type Dog struct {
 		Bark func() string
 	}
-	expectedErr := Error{
-		Message:"undefined symbol 'x'",
-		Pos:ast.Position{
-			Line:2,
-			Column:1,
-		},
-	}
+	expectedRecoverResult := "function run error: undefined symbol 'x' - at line 2, column 1"
 
 	defer func() {
-		if err := recover(); err != nil {
-			if err, ok := err.(*Error); !ok || *err != expectedErr {
-				t.Errorf("execute error - received %#v - expected: %#v", err, expectedErr)
+		if recoverResult := recover(); recoverResult != nil {
+			if recoverResult != expectedRecoverResult {
+				t.Errorf("execute error - received %#v - expected: %#v", recoverResult, expectedRecoverResult)
 			}
 		}
 	}()


### PR DESCRIPTION
convertVMFunctionToType panics strings if any error happens, which blocks invokers form acquiring the position where errors occur. If we could panic the raw vm.Error, the invoker will be able to report the line and column of the error. IDEs and programmers will benefit from the change. Thanks. :)