### PR TITLE
Add go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/mattn/anko
+
+go 1.13


### PR DESCRIPTION
This enables build anko on go module mode. Since anko have no any other dependencies, this change's only benifit is to build anko without GOPATH. And go module is the de facto depenency manage system I think we should use it for other project to embed anko easily.