### PR TITLE
Allow defining packages for environments

### DIFF
--- a/env/env.go
+++ b/env/env.go
@@ -21,6 +21,8 @@ type (
 		parent         *Env
 		values         map[string]reflect.Value
 		types          map[string]reflect.Type
+		packages       map[string]map[string]reflect.Value
+		packageTypes   map[string]map[string]reflect.Type
 		externalLookup ExternalLookup
 	}
 )

--- a/env/envPackage.go
+++ b/env/envPackage.go
@@ -1,0 +1,76 @@
+package env
+
+import "reflect"
+
+// Package returns the methods for the package defined by name.
+// If no package is found by this name in the environment,
+// the globally defined package with this name is returned.
+func (e *Env) Package(name string) map[string]reflect.Value {
+	e.rwMutex.RLock()
+	pkg, ok := e.packages[name]
+	e.rwMutex.RUnlock()
+
+	if ok {
+		return pkg
+	}
+
+	if e.parent == nil {
+		pkg, ok := Packages[name]
+		if ok {
+			return pkg
+		}
+	}
+
+	return nil
+}
+
+// DefinePackage defines methods for the package name.
+func (e *Env) DefinePackage(name string, values map[string]reflect.Value) {
+	e.rwMutex.RLock()
+	defer e.rwMutex.RUnlock()
+
+	if e.packages == nil {
+		e.packages = map[string]map[string]reflect.Value{}
+	}
+	e.packages[name] = make(map[string]reflect.Value, len(values))
+	for k, v := range values {
+		e.packages[name][k] = v
+	}
+}
+
+// PackageTypes returns the types for the package defined by name.
+// If no package is found by this name in the environment,
+// the globally defined package with this name is returned
+func (e *Env) PackageTypes(name string) map[string]reflect.Type {
+	e.rwMutex.RLock()
+	pkg, ok := e.packageTypes[name]
+	e.rwMutex.RUnlock()
+
+	if ok {
+		return pkg
+	}
+
+	if e.parent == nil {
+		pkg, ok := PackageTypes[name]
+		if ok {
+			return pkg
+		}
+	}
+
+	return nil
+}
+
+// DefinePackageTypes defines types for the package name.
+func (e *Env) DefinePackageTypes(name string, types map[string]reflect.Type) {
+	e.rwMutex.RLock()
+	defer e.rwMutex.RUnlock()
+
+	if e.packageTypes == nil {
+		e.packageTypes = map[string]map[string]reflect.Type{}
+	}
+
+	e.packageTypes[name] = make(map[string]reflect.Type, len(types))
+	for k, v := range types {
+		e.packageTypes[name][k] = v
+	}
+}

--- a/vm/vmExpr.go
+++ b/vm/vmExpr.go
@@ -522,8 +522,8 @@ func (runInfo *runInfoStruct) invokeExpr() {
 		name := runInfo.rv.String()
 		runInfo.rv = nilValue
 
-		methods, ok := env.Packages[name]
-		if !ok {
+		methods := runInfo.env.Package(name)
+		if methods == nil {
 			runInfo.err = newStringError(expr, "package not found: "+name)
 			return
 		}
@@ -537,8 +537,8 @@ func (runInfo *runInfoStruct) invokeExpr() {
 			}
 		}
 
-		types, ok := env.PackageTypes[name]
-		if ok {
+		types := runInfo.env.PackageTypes(name)
+		if types != nil {
 			for typeName, typeValue := range types {
 				err = pack.DefineReflectType(typeName, typeValue)
 				if err != nil {


### PR DESCRIPTION
This change enables environments to have a different set of packages. Accessing a package can now be protected by the environment mutex.

Fixes mattn/anko#358