### PR TITLE
Implement binary literals

### DIFF
--- a/misc/vim/syntax/anko.vim
+++ b/misc/vim/syntax/anko.vim
@@ -79,11 +79,13 @@ syn region      ankoParen             start='(' end=')' transparent
 " Integers
 syn match       ankoDecimalInt        "\<\d\+\([Ee]\d\+\)\?\>"
 syn match       ankoHexadecimalInt    "\<0x\x\+\>"
+syn match       ankoBinaryInt         "\<0b[01]\+\>"
 syn match       ankoOctalInt          "\<0\o\+\>"
 syn match       ankoOctalError        "\<0\o*[89]\d*\>"
 
 hi def link     ankoDecimalInt        Integer
 hi def link     ankoHexadecimalInt    Integer
+hi def link     ankoBinaryInt    Integer
 hi def link     ankoOctalInt          Integer
 hi def link     Integer             Number
 

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -352,6 +352,11 @@ func isHex(ch rune) bool {
 	return ('0' <= ch && ch <= '9') || ('a' <= ch && ch <= 'f') || ('A' <= ch && ch <= 'F')
 }
 
+// isBinary returns true if the rune is a binary digit.
+func isBinary(ch rune) bool {
+	return ch == '0' || ch == '1'
+}
+
 // isEOL returns true if the rune is at end-of-line or end-of-file.
 func isEOL(ch rune) bool {
 	return ch == '\n' || ch == -1
@@ -444,6 +449,14 @@ func (s *Scanner) scanNumber() (string, error) {
 		result = append(result, 'x')
 		s.next()
 		for isHex(s.peek()) {
+			result = append(result, s.peek())
+			s.next()
+		}
+	} else if result[0] == '0' && (s.peek() == 'b' || s.peek() == 'B') {
+		// binary
+		result = append(result, 'b')
+		s.next()
+		for isBinary(s.peek()) {
 			result = append(result, s.peek())
 			s.next()
 		}
@@ -625,6 +638,15 @@ func toNumber(numString string) (reflect.Value, error) {
 	// hex
 	if len(numString) > 3 && numString[0:3] == "-0x" {
 		i, err := strconv.ParseInt("-"+numString[3:], 16, 64)
+		if err != nil {
+			return nilValue, err
+		}
+		return reflect.ValueOf(i), nil
+	}
+
+	// binary
+	if len(numString) > 2 && numString[0:2] == "0b" {
+		i, err := strconv.ParseInt(numString[2:], 2, 64)
 		if err != nil {
 			return nilValue, err
 		}

--- a/vm/vmToX.go
+++ b/vm/vmToX.go
@@ -128,6 +128,8 @@ func tryToInt64(v reflect.Value) (int64, error) {
 		var err error
 		if strings.HasPrefix(s, "0x") {
 			i, err = strconv.ParseInt(s, 16, 64)
+		} else if strings.HasPrefix(s, "0b") {
+			i, err = strconv.ParseInt(s, 2, 64)
 		} else {
 			i, err = strconv.ParseInt(s, 10, 64)
 		}
@@ -167,6 +169,8 @@ func tryToInt(v reflect.Value) (int, error) {
 		var err error
 		if strings.HasPrefix(s, "0x") {
 			i, err = strconv.ParseInt(s, 16, 64)
+		} else if strings.HasPrefix(s, "0b") {
+			i, err = strconv.ParseInt(s, 2, 64)
 		} else {
 			i, err = strconv.ParseInt(s, 10, 64)
 		}

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -33,6 +33,7 @@ func TestNumbers(t *testing.T) {
 		{Script: `1ee1`, ParseError: fmt.Errorf("syntax error")},
 		{Script: `1e+e1`, ParseError: fmt.Errorf("syntax error")},
 		{Script: `0x1g`, ParseError: fmt.Errorf("syntax error")},
+		{Script: `0b2`, ParseError: fmt.Errorf("syntax error")},
 		{Script: `9223372036854775808`, ParseError: fmt.Errorf("invalid number: 9223372036854775808")},
 		{Script: `-9223372036854775809`, ParseError: fmt.Errorf("invalid number: -9223372036854775809")},
 
@@ -70,6 +71,10 @@ func TestNumbers(t *testing.T) {
 		{Script: `-0xf`, RunOutput: int64(-15)},
 		{Script: `-0Xf`, RunOutput: int64(-15)},
 		{Script: `-0x7FFFFFFFFFFFFFFF`, RunOutput: int64(-9223372036854775807)},
+
+		{Script: `0b1`, RunOutput: int64(1)},
+		{Script: `0b001100`, RunOutput: int64(12)},
+		{Script: `0b111111111111111111111111111111111111111111111111111111111111111`, RunOutput: int64(9223372036854775807)},
 	}
 	runTests(t, tests, nil, &Options{Debug: true})
 }
@@ -1234,6 +1239,7 @@ type Bar struct {
 func (f Foo) ValueReceiver() int {
 	return f.Value
 }
+
 func (b *Bar) PointerReceiver() (int, int) {
 	b.Value = 0
 	*b.Ref = 0
@@ -1369,7 +1375,6 @@ func TestLetsStatementPosition(t *testing.T) {
 
 		return nil
 	})
-
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This adds support for binary literals such as `0b001100` or `0B101010`.