### PR TITLE
Fix parser hang on unrecognized runes

### DIFF
--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -330,6 +330,7 @@ retry:
 			err = fmt.Errorf("syntax error on '%v' at %v:%v", string(ch), pos.Line, pos.Column)
 			tok = int(ch)
 			lit = string(ch)
+			s.next()
 			return
 		}
 		s.next()

--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -1,0 +1,23 @@
+package parser
+
+import (
+	"testing"
+)
+
+func TestParseSrcInvalidRune(t *testing.T) {
+	// Regression test for issue #341. The scanner did not advance past
+	// runes it could not tokenize, so the parser looped forever.
+	tests := []string{
+		"",
+		"a = ",
+		"",
+		"@",
+		"$",
+	}
+	for _, src := range tests {
+		_, err := ParseSrc(src)
+		if err == nil {
+			t.Errorf("ParseSrc(%q) expected syntax error, got nil", src)
+		}
+	}
+}


### PR DESCRIPTION
The scanner returned without advancing past runes it could not tokenize. Rune values at U+E000 and above also collide with goyacc's internal token numbering, so the parser treated them as valid tokens and requested more input forever, spinning on the same rune. Advance the scanner before returning the syntax error so parsing always terminates.

Fixes #341