### PR TITLE
Return errors instead of panicking on invalid runtime operations

### DIFF
--- a/vm/vmOperator.go
+++ b/vm/vmOperator.go
@@ -220,7 +220,13 @@ func (runInfo *runInfoStruct) invokeOperator() {
 		switch operator.Operator {
 		case "*":
 			if lhsV.Kind() == reflect.String && (runInfo.rv.Kind() == reflect.Int || runInfo.rv.Kind() == reflect.Int32 || runInfo.rv.Kind() == reflect.Int64) {
-				runInfo.rv = reflect.ValueOf(strings.Repeat(toString(lhsV), int(toInt64(runInfo.rv))))
+				count := toInt64(runInfo.rv)
+				if count < 0 {
+					runInfo.err = newStringError(operator, "negative repeat count")
+					runInfo.rv = nilValue
+					return
+				}
+				runInfo.rv = reflect.ValueOf(strings.Repeat(toString(lhsV), int(count)))
 				return
 			}
 			if lhsV.Kind() == reflect.Float64 || runInfo.rv.Kind() == reflect.Float64 {
@@ -231,7 +237,13 @@ func (runInfo *runInfoStruct) invokeOperator() {
 		case "/":
 			runInfo.rv = float64Value(toFloat64(lhsV) / toFloat64(runInfo.rv))
 		case "%":
-			runInfo.rv = int64Value(toInt64(lhsV) % toInt64(runInfo.rv))
+			rhs := toInt64(runInfo.rv)
+			if rhs == 0 {
+				runInfo.err = newStringError(operator, "integer divide by zero")
+				runInfo.rv = nilValue
+				return
+			}
+			runInfo.rv = int64Value(toInt64(lhsV) % rhs)
 		case ">>":
 			runInfo.rv = int64Value(toInt64(lhsV) >> uint64(toInt64(runInfo.rv)))
 		case "<<":

--- a/vm/vmOperators_test.go
+++ b/vm/vmOperators_test.go
@@ -149,9 +149,11 @@ func TestBasicOperators(t *testing.T) {
 		{Script: `a % 3`, Input: map[string]interface{}{"a": int64(2)}, RunOutput: int64(2), Output: map[string]interface{}{"a": int64(2)}},
 		{Script: `a % 2`, Input: map[string]interface{}{"a": float64(2.1)}, RunOutput: int64(0), Output: map[string]interface{}{"a": float64(2.1)}},
 		{Script: `a % 3`, Input: map[string]interface{}{"a": float64(2.1)}, RunOutput: int64(2), Output: map[string]interface{}{"a": float64(2.1)}},
+		{Script: `a % 0`, Input: map[string]interface{}{"a": int64(2)}, RunError: fmt.Errorf("integer divide by zero"), Output: map[string]interface{}{"a": int64(2)}},
 
 		{Script: `a * 4`, Input: map[string]interface{}{"a": "a"}, RunOutput: "aaaa", Output: map[string]interface{}{"a": "a"}},
 		{Script: `a * 4.0`, Input: map[string]interface{}{"a": "a"}, RunOutput: float64(0), Output: map[string]interface{}{"a": "a"}},
+		{Script: `a * -1`, Input: map[string]interface{}{"a": "a"}, RunError: fmt.Errorf("negative repeat count"), Output: map[string]interface{}{"a": "a"}},
 
 		{Script: `-a`, Input: map[string]interface{}{"a": nil}, RunOutput: float64(-0), Output: map[string]interface{}{"a": nil}},
 		{Script: `-a`, Input: map[string]interface{}{"a": int32(1)}, RunOutput: int64(-1), Output: map[string]interface{}{"a": int32(1)}},

--- a/vm/vmStmt.go
+++ b/vm/vmStmt.go
@@ -724,8 +724,13 @@ func (runInfo *runInfoStruct) runSingleStmt() {
 			return
 		}
 		if runInfo.rv.Kind() == reflect.Chan {
-			runInfo.rv.Close()
+			ch := runInfo.rv
 			runInfo.rv = nilValue
+			if !runInfo.options.Debug {
+				// captures panic
+				defer recoverFunc(runInfo)
+			}
+			ch.Close()
 			return
 		}
 		runInfo.err = newStringError(stmt, "type cannot be "+runInfo.rv.Kind().String()+" for close")

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -612,6 +612,8 @@ func TestChan(t *testing.T) {
 	tests := []Test{
 		// send on closed channel
 		{Script: `a = make(chan int64, 2); close(a); a <- 1`, RunError: fmt.Errorf("send on closed channel")},
+		// close of closed channel
+		{Script: `a = make(chan int64, 2); close(a); close(a)`, RunError: fmt.Errorf("close of closed channel")},
 	}
 	runTests(t, tests, nil, &Options{Debug: false})
 


### PR DESCRIPTION
Three script inputs crashed the host program with an uncaught panic:

- `5 % 0` — integer divide by zero
- `"abc" * -1` — negative strings.Repeat count
- `close(a); close(a)` — close of closed channel

The first two now return a VM error with position information. Double close is recovered the same way channel send already handles send-on-closed-channel.