### PR TITLE
Fix panics on assignments with empty left or right side

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -201,10 +201,10 @@ const yyEofCode = 1
 const yyErrCode = 2
 const yyInitialStackSize = 16
 
-//line parser.go.y:1090
+//line parser.go.y:1104
 
 //line yacctab:1
-var yyExca = [...]int{
+var yyExca = [...]int16{
 	-1, 1,
 	1, -1,
 	-2, 0,
@@ -299,7 +299,7 @@ const yyPrivate = 57344
 
 const yyLast = 3907
 
-var yyAct = [...]int{
+var yyAct = [...]int16{
 	71, 268, 33, 23, 232, 320, 321, 36, 116, 323,
 	322, 5, 8, 288, 377, 72, 8, 267, 76, 8,
 	8, 124, 386, 8, 8, 127, 281, 114, 117, 121,
@@ -693,7 +693,7 @@ var yyAct = [...]int{
 	84, 0, 0, 0, 85, 0, 87,
 }
 
-var yyPact = [...]int{
+var yyPact = [...]int16{
 	-67, -1000, 631, -67, -1000, -71, -71, -1000, -1000, -1000,
 	-1000, -1000, -1000, 3490, 3490, 306, 213, 3782, 93, 89,
 	283, -1000, -1000, 1226, -1000, -1000, 3490, 465, 3490, -1000,
@@ -741,14 +741,14 @@ var yyPact = [...]int{
 	96, 164, -67, -1000, -67, 78, 46, -1000, -1000,
 }
 
-var yyPgo = [...]int{
+var yyPgo = [...]int16{
 	0, 41, 353, 279, 303, 352, 350, 349, 348, 346,
 	344, 6, 5, 56, 0, 8, 25, 343, 2, 340,
 	338, 7, 337, 4, 335, 333, 330, 328, 323, 321,
 	320, 316, 314, 313, 311, 159, 1, 179, 48,
 }
 
-var yyR1 = [...]int{
+var yyR1 = [...]int8{
 	0, 1, 1, 2, 2, 3, 3, 3, 3, 3,
 	3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
 	3, 3, 3, 3, 3, 3, 3, 4, 4, 5,
@@ -770,7 +770,7 @@ var yyR1 = [...]int{
 	36, 36,
 }
 
-var yyR2 = [...]int{
+var yyR2 = [...]int8{
 	0, 1, 2, 2, 3, 0, 1, 1, 1, 2,
 	2, 5, 13, 12, 9, 8, 6, 5, 6, 5,
 	4, 6, 4, 1, 1, 1, 1, 1, 1, 4,
@@ -792,7 +792,7 @@ var yyR2 = [...]int{
 	1, 1,
 }
 
-var yyChk = [...]int{
+var yyChk = [...]int16{
 	-1000, -1, -33, -2, -34, 78, -37, -38, 83, -3,
 	-4, 38, 39, 10, 12, 28, 29, 47, 55, 56,
 	-7, -8, -9, -14, -5, -6, 13, 15, 44, -19,
@@ -840,7 +840,7 @@ var yyChk = [...]int{
 	-36, 31, 73, 74, 73, -1, -1, 74, 74,
 }
 
-var yyDef = [...]int{
+var yyDef = [...]int16{
 	168, -2, -2, 168, 169, 172, 171, 175, 177, 3,
 	6, 7, 8, 57, 0, 0, 0, 0, 0, 0,
 	23, 24, 25, -2, 27, 28, 0, -2, 0, 61,
@@ -888,7 +888,7 @@ var yyDef = [...]int{
 	0, 0, 168, 88, 168, 0, 0, 13, 12,
 }
 
-var yyTok1 = [...]int{
+var yyTok1 = [...]int8{
 	1, 3, 3, 3, 3, 3, 3, 3, 3, 3,
 	83, 3, 3, 3, 3, 3, 3, 3, 3, 3,
 	3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
@@ -904,7 +904,7 @@ var yyTok1 = [...]int{
 	3, 3, 3, 73, 66, 74,
 }
 
-var yyTok2 = [...]int{
+var yyTok2 = [...]int8{
 	2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
 	12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
 	22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
@@ -913,7 +913,7 @@ var yyTok2 = [...]int{
 	52, 53, 54, 55, 56, 57, 58, 72,
 }
 
-var yyTok3 = [...]int{
+var yyTok3 = [...]int8{
 	0,
 }
 
@@ -995,9 +995,9 @@ func yyErrorMessage(state, lookAhead int) string {
 	expected := make([]int, 0, 4)
 
 	// Look for shiftable tokens.
-	base := yyPact[state]
+	base := int(yyPact[state])
 	for tok := TOKSTART; tok-1 < len(yyToknames); tok++ {
-		if n := base + tok; n >= 0 && n < yyLast && yyChk[yyAct[n]] == tok {
+		if n := base + tok; n >= 0 && n < yyLast && int(yyChk[int(yyAct[n])]) == tok {
 			if len(expected) == cap(expected) {
 				return res
 			}
@@ -1007,13 +1007,13 @@ func yyErrorMessage(state, lookAhead int) string {
 
 	if yyDef[state] == -2 {
 		i := 0
-		for yyExca[i] != -1 || yyExca[i+1] != state {
+		for yyExca[i] != -1 || int(yyExca[i+1]) != state {
 			i += 2
 		}
 
 		// Look for tokens that we accept or reduce.
 		for i += 2; yyExca[i] >= 0; i += 2 {
-			tok := yyExca[i]
+			tok := int(yyExca[i])
 			if tok < TOKSTART || yyExca[i+1] == 0 {
 				continue
 			}
@@ -1044,30 +1044,30 @@ func yylex1(lex yyLexer, lval *yySymType) (char, token int) {
 	token = 0
 	char = lex.Lex(lval)
 	if char <= 0 {
-		token = yyTok1[0]
+		token = int(yyTok1[0])
 		goto out
 	}
 	if char < len(yyTok1) {
-		token = yyTok1[char]
+		token = int(yyTok1[char])
 		goto out
 	}
 	if char >= yyPrivate {
 		if char < yyPrivate+len(yyTok2) {
-			token = yyTok2[char-yyPrivate]
+			token = int(yyTok2[char-yyPrivate])
 			goto out
 		}
 	}
 	for i := 0; i < len(yyTok3); i += 2 {
-		token = yyTok3[i+0]
+		token = int(yyTok3[i+0])
 		if token == char {
-			token = yyTok3[i+1]
+			token = int(yyTok3[i+1])
 			goto out
 		}
 	}
 
 out:
 	if token == 0 {
-		token = yyTok2[1] /* unknown char */
+		token = int(yyTok2[1]) /* unknown char */
 	}
 	if yyDebug >= 3 {
 		__yyfmt__.Printf("lex %s(%d)\n", yyTokname(token), uint(char))
@@ -1122,7 +1122,7 @@ yystack:
 	yyS[yyp].yys = yystate
 
 yynewstate:
-	yyn = yyPact[yystate]
+	yyn = int(yyPact[yystate])
 	if yyn <= yyFlag {
 		goto yydefault /* simple state */
 	}
@@ -1133,8 +1133,8 @@ yynewstate:
 	if yyn < 0 || yyn >= yyLast {
 		goto yydefault
 	}
-	yyn = yyAct[yyn]
-	if yyChk[yyn] == yytoken { /* valid shift */
+	yyn = int(yyAct[yyn])
+	if int(yyChk[yyn]) == yytoken { /* valid shift */
 		yyrcvr.char = -1
 		yytoken = -1
 		yyVAL = yyrcvr.lval
@@ -1147,7 +1147,7 @@ yynewstate:
 
 yydefault:
 	/* default state action */
-	yyn = yyDef[yystate]
+	yyn = int(yyDef[yystate])
 	if yyn == -2 {
 		if yyrcvr.char < 0 {
 			yyrcvr.char, yytoken = yylex1(yylex, &yyrcvr.lval)
@@ -1156,18 +1156,18 @@ yydefault:
 		/* look through exception table */
 		xi := 0
 		for {
-			if yyExca[xi+0] == -1 && yyExca[xi+1] == yystate {
+			if yyExca[xi+0] == -1 && int(yyExca[xi+1]) == yystate {
 				break
 			}
 			xi += 2
 		}
 		for xi += 2; ; xi += 2 {
-			yyn = yyExca[xi+0]
+			yyn = int(yyExca[xi+0])
 			if yyn < 0 || yyn == yytoken {
 				break
 			}
 		}
-		yyn = yyExca[xi+1]
+		yyn = int(yyExca[xi+1])
 		if yyn < 0 {
 			goto ret0
 		}
@@ -1189,10 +1189,10 @@ yydefault:
 
 			/* find a state where "error" is a legal shift action */
 			for yyp >= 0 {
-				yyn = yyPact[yyS[yyp].yys] + yyErrCode
+				yyn = int(yyPact[yyS[yyp].yys]) + yyErrCode
 				if yyn >= 0 && yyn < yyLast {
-					yystate = yyAct[yyn] /* simulate a shift of "error" */
-					if yyChk[yystate] == yyErrCode {
+					yystate = int(yyAct[yyn]) /* simulate a shift of "error" */
+					if int(yyChk[yystate]) == yyErrCode {
 						goto yystack
 					}
 				}
@@ -1228,7 +1228,7 @@ yydefault:
 	yypt := yyp
 	_ = yypt // guard against "declared and not used"
 
-	yyp -= yyR2[yyn]
+	yyp -= int(yyR2[yyn])
 	// yyp is now the index of $0. Perform the default action. Iff the
 	// reduced production is ε, $1 is possibly out of range.
 	if yyp+1 >= len(yyS) {
@@ -1239,16 +1239,16 @@ yydefault:
 	yyVAL = yyS[yyp+1]
 
 	/* consult goto table to find next state */
-	yyn = yyR1[yyn]
-	yyg := yyPgo[yyn]
+	yyn = int(yyR1[yyn])
+	yyg := int(yyPgo[yyn])
 	yyj := yyg + yyS[yyp].yys + 1
 
 	if yyj >= yyLast {
-		yystate = yyAct[yyg]
+		yystate = int(yyAct[yyg])
 	} else {
-		yystate = yyAct[yyj]
-		if yyChk[yystate] != -yyn {
-			yystate = yyAct[yyg]
+		yystate = int(yyAct[yyj])
+		if int(yyChk[yystate]) != -yyn {
+			yystate = int(yyAct[yyg])
 		}
 	}
 	// dummy call; replaced with literal code
@@ -1472,27 +1472,37 @@ yydefault:
 		yyDollar = yyS[yypt-3 : yypt+1]
 //line parser.go.y:272
 		{
-			if len(yyDollar[1].exprs) == 2 && len(yyDollar[3].exprs) == 1 {
-				if _, ok := yyDollar[3].exprs[0].(*ast.ItemExpr); ok {
-					yyVAL.stmt_lets = &ast.LetMapItemStmt{LHSS: yyDollar[1].exprs, RHS: yyDollar[3].exprs[0]}
+			if len(yyDollar[1].exprs) < 1 {
+				yylex.Error("missing expressions on left side of '='")
+				yyVAL.stmt_lets = &ast.LetsStmt{LHSS: yyDollar[1].exprs, RHSS: yyDollar[3].exprs}
+				yyVAL.stmt_lets.SetPosition(yyDollar[2].tok.Position())
+			} else if len(yyDollar[3].exprs) < 1 {
+				yylex.Error("missing expressions on right side of '='")
+				yyVAL.stmt_lets = &ast.LetsStmt{LHSS: yyDollar[1].exprs, RHSS: yyDollar[3].exprs}
+				yyVAL.stmt_lets.SetPosition(yyDollar[1].exprs[0].Position())
+			} else {
+				if len(yyDollar[1].exprs) == 2 && len(yyDollar[3].exprs) == 1 {
+					if _, ok := yyDollar[3].exprs[0].(*ast.ItemExpr); ok {
+						yyVAL.stmt_lets = &ast.LetMapItemStmt{LHSS: yyDollar[1].exprs, RHS: yyDollar[3].exprs[0]}
+					} else {
+						yyVAL.stmt_lets = &ast.LetsStmt{LHSS: yyDollar[1].exprs, RHSS: yyDollar[3].exprs}
+					}
 				} else {
 					yyVAL.stmt_lets = &ast.LetsStmt{LHSS: yyDollar[1].exprs, RHSS: yyDollar[3].exprs}
 				}
-			} else {
-				yyVAL.stmt_lets = &ast.LetsStmt{LHSS: yyDollar[1].exprs, RHSS: yyDollar[3].exprs}
+				yyVAL.stmt_lets.SetPosition(yyDollar[1].exprs[0].Position())
 			}
-			yyVAL.stmt_lets.SetPosition(yyDollar[1].exprs[0].Position())
 		}
 	case 32:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line parser.go.y:285
+//line parser.go.y:295
 		{
 			yyVAL.stmt_lets = &ast.ChanStmt{LHS: yyDollar[1].expr, RHS: yyDollar[3].expr}
 			yyVAL.stmt_lets.SetPosition(yyDollar[1].expr.Position())
 		}
 	case 33:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line parser.go.y:290
+//line parser.go.y:300
 		{
 			if len(yyDollar[1].exprs) == 2 {
 				chanStmt := &ast.ChanStmt{LHS: yyDollar[1].exprs[0].(ast.Expr), OkExpr: yyDollar[1].exprs[1].(ast.Expr), RHS: yyDollar[3].expr}
@@ -1502,25 +1512,29 @@ yydefault:
 				yylex.Error("missing expressions on left side of channel operator")
 				yyVAL.stmt_lets = &ast.ChanStmt{RHS: yyDollar[3].expr}
 				yyVAL.stmt_lets.SetPosition(yyDollar[2].tok.Position())
+			} else {
+				yylex.Error("too many expressions on left side of channel operator")
+				yyVAL.stmt_lets = &ast.ChanStmt{RHS: yyDollar[3].expr}
+				yyVAL.stmt_lets.SetPosition(yyDollar[1].exprs[0].Position())
 			}
 		}
 	case 34:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line parser.go.y:304
+//line parser.go.y:318
 		{
 			yyVAL.stmt_if = &ast.IfStmt{If: yyDollar[2].expr, Then: yyDollar[4].compstmt, Else: nil}
 			yyVAL.stmt_if.SetPosition(yyDollar[1].tok.Position())
 		}
 	case 35:
 		yyDollar = yyS[yypt-7 : yypt+1]
-//line parser.go.y:309
+//line parser.go.y:323
 		{
 			ifStmt := yyDollar[1].stmt_if.(*ast.IfStmt)
 			ifStmt.ElseIf = append(ifStmt.ElseIf, &ast.IfStmt{If: yyDollar[4].expr, Then: yyDollar[6].compstmt})
 		}
 	case 36:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line parser.go.y:314
+//line parser.go.y:328
 		{
 			ifStmt := yyDollar[1].stmt_if.(*ast.IfStmt)
 			if ifStmt.Else != nil {
@@ -1530,14 +1544,14 @@ yydefault:
 		}
 	case 37:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line parser.go.y:324
+//line parser.go.y:338
 		{
 			yyVAL.stmt_for = &ast.LoopStmt{Stmt: yyDollar[3].compstmt}
 			yyVAL.stmt_for.SetPosition(yyDollar[1].tok.Position())
 		}
 	case 38:
 		yyDollar = yyS[yypt-7 : yypt+1]
-//line parser.go.y:329
+//line parser.go.y:343
 		{
 			if len(yyDollar[2].expr_idents) < 1 {
 				yylex.Error("missing identifier")
@@ -1550,70 +1564,70 @@ yydefault:
 		}
 	case 39:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line parser.go.y:340
+//line parser.go.y:354
 		{
 			yyVAL.stmt_for = &ast.LoopStmt{Expr: yyDollar[2].expr, Stmt: yyDollar[4].compstmt}
 			yyVAL.stmt_for.SetPosition(yyDollar[1].tok.Position())
 		}
 	case 40:
 		yyDollar = yyS[yypt-6 : yypt+1]
-//line parser.go.y:345
+//line parser.go.y:359
 		{
 			yyVAL.stmt_for = &ast.CForStmt{Stmt: yyDollar[5].compstmt}
 			yyVAL.stmt_for.SetPosition(yyDollar[1].tok.Position())
 		}
 	case 41:
 		yyDollar = yyS[yypt-7 : yypt+1]
-//line parser.go.y:350
+//line parser.go.y:364
 		{
 			yyVAL.stmt_for = &ast.CForStmt{Expr3: yyDollar[4].expr, Stmt: yyDollar[6].compstmt}
 			yyVAL.stmt_for.SetPosition(yyDollar[1].tok.Position())
 		}
 	case 42:
 		yyDollar = yyS[yypt-7 : yypt+1]
-//line parser.go.y:355
+//line parser.go.y:369
 		{
 			yyVAL.stmt_for = &ast.CForStmt{Expr2: yyDollar[3].expr, Stmt: yyDollar[6].compstmt}
 			yyVAL.stmt_for.SetPosition(yyDollar[1].tok.Position())
 		}
 	case 43:
 		yyDollar = yyS[yypt-8 : yypt+1]
-//line parser.go.y:360
+//line parser.go.y:374
 		{
 			yyVAL.stmt_for = &ast.CForStmt{Expr2: yyDollar[3].expr, Expr3: yyDollar[5].expr, Stmt: yyDollar[7].compstmt}
 			yyVAL.stmt_for.SetPosition(yyDollar[1].tok.Position())
 		}
 	case 44:
 		yyDollar = yyS[yypt-7 : yypt+1]
-//line parser.go.y:365
+//line parser.go.y:379
 		{
 			yyVAL.stmt_for = &ast.CForStmt{Stmt1: yyDollar[2].stmt_var_or_lets, Stmt: yyDollar[6].compstmt}
 			yyVAL.stmt_for.SetPosition(yyDollar[1].tok.Position())
 		}
 	case 45:
 		yyDollar = yyS[yypt-8 : yypt+1]
-//line parser.go.y:370
+//line parser.go.y:384
 		{
 			yyVAL.stmt_for = &ast.CForStmt{Stmt1: yyDollar[2].stmt_var_or_lets, Expr3: yyDollar[5].expr, Stmt: yyDollar[7].compstmt}
 			yyVAL.stmt_for.SetPosition(yyDollar[1].tok.Position())
 		}
 	case 46:
 		yyDollar = yyS[yypt-8 : yypt+1]
-//line parser.go.y:375
+//line parser.go.y:389
 		{
 			yyVAL.stmt_for = &ast.CForStmt{Stmt1: yyDollar[2].stmt_var_or_lets, Expr2: yyDollar[4].expr, Stmt: yyDollar[7].compstmt}
 			yyVAL.stmt_for.SetPosition(yyDollar[1].tok.Position())
 		}
 	case 47:
 		yyDollar = yyS[yypt-9 : yypt+1]
-//line parser.go.y:380
+//line parser.go.y:394
 		{
 			yyVAL.stmt_for = &ast.CForStmt{Stmt1: yyDollar[2].stmt_var_or_lets, Expr2: yyDollar[4].expr, Expr3: yyDollar[6].expr, Stmt: yyDollar[8].compstmt}
 			yyVAL.stmt_for.SetPosition(yyDollar[1].tok.Position())
 		}
 	case 48:
 		yyDollar = yyS[yypt-7 : yypt+1]
-//line parser.go.y:387
+//line parser.go.y:401
 		{
 			switchStmt := yyDollar[5].stmt_switch_cases.(*ast.SwitchStmt)
 			switchStmt.Expr = yyDollar[2].expr
@@ -1622,25 +1636,25 @@ yydefault:
 		}
 	case 49:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line parser.go.y:396
+//line parser.go.y:410
 		{
 			yyVAL.stmt_switch_cases = &ast.SwitchStmt{}
 		}
 	case 50:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line parser.go.y:400
+//line parser.go.y:414
 		{
 			yyVAL.stmt_switch_cases = &ast.SwitchStmt{Default: yyDollar[1].stmt_switch_default}
 		}
 	case 51:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line parser.go.y:404
+//line parser.go.y:418
 		{
 			yyVAL.stmt_switch_cases = &ast.SwitchStmt{Cases: []ast.Stmt{yyDollar[1].stmt_switch_case}}
 		}
 	case 52:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line parser.go.y:408
+//line parser.go.y:422
 		{
 			switchStmt := yyDollar[1].stmt_switch_cases.(*ast.SwitchStmt)
 			switchStmt.Cases = append(switchStmt.Cases, yyDollar[2].stmt_switch_case)
@@ -1648,7 +1662,7 @@ yydefault:
 		}
 	case 53:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line parser.go.y:414
+//line parser.go.y:428
 		{
 			switchStmt := yyDollar[1].stmt_switch_cases.(*ast.SwitchStmt)
 			if switchStmt.Default != nil {
@@ -1658,39 +1672,39 @@ yydefault:
 		}
 	case 54:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line parser.go.y:424
+//line parser.go.y:438
 		{
 			yyVAL.stmt_switch_case = &ast.SwitchCaseStmt{Exprs: []ast.Expr{yyDollar[2].expr}, Stmt: yyDollar[4].compstmt}
 			yyVAL.stmt_switch_case.SetPosition(yyDollar[1].tok.Position())
 		}
 	case 55:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line parser.go.y:429
+//line parser.go.y:443
 		{
 			yyVAL.stmt_switch_case = &ast.SwitchCaseStmt{Exprs: yyDollar[2].exprs, Stmt: yyDollar[4].compstmt}
 			yyVAL.stmt_switch_case.SetPosition(yyDollar[1].tok.Position())
 		}
 	case 56:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line parser.go.y:436
+//line parser.go.y:450
 		{
 			yyVAL.stmt_switch_default = yyDollar[3].compstmt
 		}
 	case 57:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line parser.go.y:443
+//line parser.go.y:457
 		{
 			yyVAL.exprs = nil
 		}
 	case 58:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line parser.go.y:447
+//line parser.go.y:461
 		{
 			yyVAL.exprs = []ast.Expr{yyDollar[1].expr}
 		}
 	case 59:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line parser.go.y:451
+//line parser.go.y:465
 		{
 			if len(yyDollar[1].exprs) == 0 {
 				yylex.Error("syntax error: unexpected ','")
@@ -1699,7 +1713,7 @@ yydefault:
 		}
 	case 60:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line parser.go.y:458
+//line parser.go.y:472
 		{
 			if len(yyDollar[1].exprs) == 0 {
 				yylex.Error("syntax error: unexpected ','")
@@ -1708,61 +1722,61 @@ yydefault:
 		}
 	case 61:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line parser.go.y:467
+//line parser.go.y:481
 		{
 			yyVAL.expr = yyDollar[1].expr_member_or_ident
 		}
 	case 62:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line parser.go.y:471
+//line parser.go.y:485
 		{
 			yyVAL.expr = yyDollar[1].expr_literals
 		}
 	case 63:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line parser.go.y:475
+//line parser.go.y:489
 		{
 			yyVAL.expr = &ast.TernaryOpExpr{Expr: yyDollar[1].expr, LHS: yyDollar[3].expr, RHS: yyDollar[5].expr}
 			yyVAL.expr.SetPosition(yyDollar[1].expr.Position())
 		}
 	case 64:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line parser.go.y:480
+//line parser.go.y:494
 		{
 			yyVAL.expr = &ast.NilCoalescingOpExpr{LHS: yyDollar[1].expr, RHS: yyDollar[3].expr}
 			yyVAL.expr.SetPosition(yyDollar[1].expr.Position())
 		}
 	case 65:
 		yyDollar = yyS[yypt-7 : yypt+1]
-//line parser.go.y:485
+//line parser.go.y:499
 		{
 			yyVAL.expr = &ast.FuncExpr{Params: yyDollar[3].expr_idents, Stmt: yyDollar[6].compstmt}
 			yyVAL.expr.SetPosition(yyDollar[1].tok.Position())
 		}
 	case 66:
 		yyDollar = yyS[yypt-8 : yypt+1]
-//line parser.go.y:490
+//line parser.go.y:504
 		{
 			yyVAL.expr = &ast.FuncExpr{Params: yyDollar[3].expr_idents, Stmt: yyDollar[7].compstmt, VarArg: true}
 			yyVAL.expr.SetPosition(yyDollar[1].tok.Position())
 		}
 	case 67:
 		yyDollar = yyS[yypt-8 : yypt+1]
-//line parser.go.y:495
+//line parser.go.y:509
 		{
 			yyVAL.expr = &ast.FuncExpr{Name: yyDollar[2].tok.Lit, Params: yyDollar[4].expr_idents, Stmt: yyDollar[7].compstmt}
 			yyVAL.expr.SetPosition(yyDollar[1].tok.Position())
 		}
 	case 68:
 		yyDollar = yyS[yypt-9 : yypt+1]
-//line parser.go.y:500
+//line parser.go.y:514
 		{
 			yyVAL.expr = &ast.FuncExpr{Name: yyDollar[2].tok.Lit, Params: yyDollar[4].expr_idents, Stmt: yyDollar[8].compstmt, VarArg: true}
 			yyVAL.expr.SetPosition(yyDollar[1].tok.Position())
 		}
 	case 69:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line parser.go.y:505
+//line parser.go.y:519
 		{
 			yyVAL.expr = &ast.ArrayExpr{}
 			if l, ok := yylex.(*Lexer); ok {
@@ -1771,7 +1785,7 @@ yydefault:
 		}
 	case 70:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line parser.go.y:510
+//line parser.go.y:524
 		{
 			yyVAL.expr = &ast.ArrayExpr{Exprs: yyDollar[3].exprs}
 			if l, ok := yylex.(*Lexer); ok {
@@ -1780,7 +1794,7 @@ yydefault:
 		}
 	case 71:
 		yyDollar = yyS[yypt-7 : yypt+1]
-//line parser.go.y:515
+//line parser.go.y:529
 		{
 			yyVAL.expr = &ast.ArrayExpr{Exprs: yyDollar[5].exprs, TypeData: &ast.TypeStruct{Kind: ast.TypeSlice, SubType: yyDollar[2].type_data, Dimensions: yyDollar[1].slice_count}}
 			if l, ok := yylex.(*Lexer); ok {
@@ -1789,7 +1803,7 @@ yydefault:
 		}
 	case 72:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line parser.go.y:520
+//line parser.go.y:534
 		{
 			yyVAL.expr = &ast.ParenExpr{SubExpr: yyDollar[2].expr}
 			if l, ok := yylex.(*Lexer); ok {
@@ -1798,63 +1812,63 @@ yydefault:
 		}
 	case 73:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line parser.go.y:525
+//line parser.go.y:539
 		{
 			yyVAL.expr = &ast.CallExpr{Name: yyDollar[1].tok.Lit, SubExprs: yyDollar[3].exprs, VarArg: true}
 			yyVAL.expr.SetPosition(yyDollar[1].tok.Position())
 		}
 	case 74:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line parser.go.y:530
+//line parser.go.y:544
 		{
 			yyVAL.expr = &ast.CallExpr{Name: yyDollar[1].tok.Lit, SubExprs: yyDollar[3].exprs}
 			yyVAL.expr.SetPosition(yyDollar[1].tok.Position())
 		}
 	case 75:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line parser.go.y:535
+//line parser.go.y:549
 		{
 			yyVAL.expr = &ast.AnonCallExpr{Expr: yyDollar[1].expr, SubExprs: yyDollar[3].exprs, VarArg: true}
 			yyVAL.expr.SetPosition(yyDollar[1].expr.Position())
 		}
 	case 76:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line parser.go.y:540
+//line parser.go.y:554
 		{
 			yyVAL.expr = &ast.AnonCallExpr{Expr: yyDollar[1].expr, SubExprs: yyDollar[3].exprs}
 			yyVAL.expr.SetPosition(yyDollar[1].expr.Position())
 		}
 	case 77:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line parser.go.y:545
+//line parser.go.y:559
 		{
 			yyVAL.expr = &ast.ItemExpr{Item: yyDollar[1].expr_ident, Index: yyDollar[3].expr}
 			yyVAL.expr.SetPosition(yyDollar[1].expr_ident.Position())
 		}
 	case 78:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line parser.go.y:550
+//line parser.go.y:564
 		{
 			yyVAL.expr = &ast.ItemExpr{Item: yyDollar[1].expr, Index: yyDollar[3].expr}
 			yyVAL.expr.SetPosition(yyDollar[1].expr.Position())
 		}
 	case 79:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line parser.go.y:555
+//line parser.go.y:569
 		{
 			yyVAL.expr = &ast.LenExpr{Expr: yyDollar[3].expr}
 			yyVAL.expr.SetPosition(yyDollar[1].tok.Position())
 		}
 	case 80:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line parser.go.y:560
+//line parser.go.y:574
 		{
 			yyVAL.expr = &ast.ImportExpr{Name: yyDollar[3].expr}
 			yyVAL.expr.SetPosition(yyDollar[1].tok.Position())
 		}
 	case 81:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line parser.go.y:565
+//line parser.go.y:579
 		{
 			if yyDollar[3].type_data.Kind == ast.TypeDefault {
 				yyDollar[3].type_data.Kind = ast.TypePtr
@@ -1866,42 +1880,42 @@ yydefault:
 		}
 	case 82:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line parser.go.y:575
+//line parser.go.y:589
 		{
 			yyVAL.expr = &ast.MakeExpr{TypeData: yyDollar[3].type_data}
 			yyVAL.expr.SetPosition(yyDollar[1].tok.Position())
 		}
 	case 83:
 		yyDollar = yyS[yypt-6 : yypt+1]
-//line parser.go.y:580
+//line parser.go.y:594
 		{
 			yyVAL.expr = &ast.MakeExpr{TypeData: yyDollar[3].type_data, LenExpr: yyDollar[5].expr}
 			yyVAL.expr.SetPosition(yyDollar[1].tok.Position())
 		}
 	case 84:
 		yyDollar = yyS[yypt-8 : yypt+1]
-//line parser.go.y:585
+//line parser.go.y:599
 		{
 			yyVAL.expr = &ast.MakeExpr{TypeData: yyDollar[3].type_data, LenExpr: yyDollar[5].expr, CapExpr: yyDollar[7].expr}
 			yyVAL.expr.SetPosition(yyDollar[1].tok.Position())
 		}
 	case 85:
 		yyDollar = yyS[yypt-7 : yypt+1]
-//line parser.go.y:590
+//line parser.go.y:604
 		{
 			yyVAL.expr = &ast.MakeTypeExpr{Name: yyDollar[4].tok.Lit, Type: yyDollar[6].expr}
 			yyVAL.expr.SetPosition(yyDollar[1].tok.Position())
 		}
 	case 86:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line parser.go.y:595
+//line parser.go.y:609
 		{
 			yyVAL.expr = &ast.IncludeExpr{ItemExpr: yyDollar[1].expr, ListExpr: yyDollar[3].expr}
 			yyVAL.expr.SetPosition(yyDollar[1].expr.Position())
 		}
 	case 87:
 		yyDollar = yyS[yypt-6 : yypt+1]
-//line parser.go.y:600
+//line parser.go.y:614
 		{
 			yyDollar[4].expr_map.TypeData = &ast.TypeStruct{Kind: ast.TypeMap, Key: &ast.TypeStruct{Name: "interface"}, SubType: &ast.TypeStruct{Name: "interface"}}
 			yyVAL.expr = yyDollar[4].expr_map
@@ -1909,7 +1923,7 @@ yydefault:
 		}
 	case 88:
 		yyDollar = yyS[yypt-10 : yypt+1]
-//line parser.go.y:606
+//line parser.go.y:620
 		{
 			yyDollar[8].expr_map.TypeData = &ast.TypeStruct{Kind: ast.TypeMap, Key: yyDollar[3].type_data, SubType: yyDollar[5].type_data}
 			yyVAL.expr = yyDollar[8].expr_map
@@ -1917,40 +1931,40 @@ yydefault:
 		}
 	case 89:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line parser.go.y:612
+//line parser.go.y:626
 		{
 			yyVAL.expr = yyDollar[3].expr_map
 			yyVAL.expr.SetPosition(yyDollar[3].expr_map.Position())
 		}
 	case 90:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line parser.go.y:617
+//line parser.go.y:631
 		{
 			yyVAL.expr = yyDollar[1].expr_slice
 			yyVAL.expr.SetPosition(yyDollar[1].expr_slice.Position())
 		}
 	case 91:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line parser.go.y:622
+//line parser.go.y:636
 		{
 			yyVAL.expr = yyDollar[1].expr_chan
 			yyVAL.expr.SetPosition(yyDollar[1].expr_chan.Position())
 		}
 	case 95:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line parser.go.y:631
+//line parser.go.y:645
 		{
 			yyVAL.expr_idents = []string{}
 		}
 	case 96:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line parser.go.y:635
+//line parser.go.y:649
 		{
 			yyVAL.expr_idents = []string{yyDollar[1].tok.Lit}
 		}
 	case 97:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line parser.go.y:639
+//line parser.go.y:653
 		{
 			if len(yyDollar[1].expr_idents) == 0 {
 				yylex.Error("syntax error: unexpected ','")
@@ -1959,13 +1973,13 @@ yydefault:
 		}
 	case 98:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line parser.go.y:648
+//line parser.go.y:662
 		{
 			yyVAL.type_data = &ast.TypeStruct{Name: yyDollar[1].tok.Lit}
 		}
 	case 99:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line parser.go.y:652
+//line parser.go.y:666
 		{
 			if yyDollar[1].type_data.Kind != ast.TypeDefault {
 				yylex.Error("not type default")
@@ -1976,7 +1990,7 @@ yydefault:
 		}
 	case 100:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line parser.go.y:661
+//line parser.go.y:675
 		{
 			if yyDollar[2].type_data.Kind == ast.TypeDefault {
 				yyDollar[2].type_data.Kind = ast.TypePtr
@@ -1987,7 +2001,7 @@ yydefault:
 		}
 	case 101:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line parser.go.y:670
+//line parser.go.y:684
 		{
 			if yyDollar[2].type_data.Kind == ast.TypeDefault {
 				yyDollar[2].type_data.Kind = ast.TypeSlice
@@ -1999,13 +2013,13 @@ yydefault:
 		}
 	case 102:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line parser.go.y:680
+//line parser.go.y:694
 		{
 			yyVAL.type_data = &ast.TypeStruct{Kind: ast.TypeMap, Key: yyDollar[3].type_data, SubType: yyDollar[5].type_data}
 		}
 	case 103:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line parser.go.y:684
+//line parser.go.y:698
 		{
 			if yyDollar[2].type_data.Kind == ast.TypeDefault {
 				yyDollar[2].type_data.Kind = ast.TypeChan
@@ -2016,19 +2030,19 @@ yydefault:
 		}
 	case 104:
 		yyDollar = yyS[yypt-6 : yypt+1]
-//line parser.go.y:693
+//line parser.go.y:707
 		{
 			yyVAL.type_data = yyDollar[4].type_data_struct
 		}
 	case 105:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line parser.go.y:699
+//line parser.go.y:713
 		{
 			yyVAL.type_data_struct = &ast.TypeStruct{Kind: ast.TypeStructType, StructNames: []string{yyDollar[1].tok.Lit}, StructTypes: []*ast.TypeStruct{yyDollar[2].type_data}}
 		}
 	case 106:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line parser.go.y:703
+//line parser.go.y:717
 		{
 			if yyDollar[1].type_data_struct == nil {
 				yylex.Error("syntax error: unexpected ','")
@@ -2038,45 +2052,45 @@ yydefault:
 		}
 	case 107:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line parser.go.y:713
+//line parser.go.y:727
 		{
 			yyVAL.slice_count = 1
 		}
 	case 108:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line parser.go.y:717
+//line parser.go.y:731
 		{
 			yyVAL.slice_count = yyDollar[3].slice_count + 1
 		}
 	case 109:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line parser.go.y:723
+//line parser.go.y:737
 		{
 			yyVAL.expr_member_or_ident = yyDollar[1].expr_member
 		}
 	case 110:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line parser.go.y:727
+//line parser.go.y:741
 		{
 			yyVAL.expr_member_or_ident = yyDollar[1].expr_ident
 		}
 	case 111:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line parser.go.y:733
+//line parser.go.y:747
 		{
 			yyVAL.expr_member = &ast.MemberExpr{Expr: yyDollar[1].expr, Name: yyDollar[3].tok.Lit}
 			yyVAL.expr_member.SetPosition(yyDollar[1].expr.Position())
 		}
 	case 112:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line parser.go.y:740
+//line parser.go.y:754
 		{
 			yyVAL.expr_ident = &ast.IdentExpr{Lit: yyDollar[1].tok.Lit}
 			yyVAL.expr_ident.SetPosition(yyDollar[1].tok.Position())
 		}
 	case 113:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line parser.go.y:747
+//line parser.go.y:761
 		{
 			num, err := toNumber("-" + yyDollar[2].tok.Lit)
 			if err != nil {
@@ -2087,7 +2101,7 @@ yydefault:
 		}
 	case 114:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line parser.go.y:756
+//line parser.go.y:770
 		{
 			num, err := toNumber(yyDollar[1].tok.Lit)
 			if err != nil {
@@ -2098,47 +2112,47 @@ yydefault:
 		}
 	case 115:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line parser.go.y:765
+//line parser.go.y:779
 		{
 			yyVAL.expr_literals = &ast.LiteralExpr{Literal: stringToValue(yyDollar[1].tok.Lit)}
 			yyVAL.expr_literals.SetPosition(yyDollar[1].tok.Position())
 		}
 	case 116:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line parser.go.y:770
+//line parser.go.y:784
 		{
 			yyVAL.expr_literals = &ast.LiteralExpr{Literal: trueValue}
 			yyVAL.expr_literals.SetPosition(yyDollar[1].tok.Position())
 		}
 	case 117:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line parser.go.y:775
+//line parser.go.y:789
 		{
 			yyVAL.expr_literals = &ast.LiteralExpr{Literal: falseValue}
 			yyVAL.expr_literals.SetPosition(yyDollar[1].tok.Position())
 		}
 	case 118:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line parser.go.y:780
+//line parser.go.y:794
 		{
 			yyVAL.expr_literals = &ast.LiteralExpr{Literal: nilValue}
 			yyVAL.expr_literals.SetPosition(yyDollar[1].tok.Position())
 		}
 	case 119:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line parser.go.y:787
+//line parser.go.y:801
 		{
 			yyVAL.expr_map = &ast.MapExpr{}
 		}
 	case 120:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line parser.go.y:791
+//line parser.go.y:805
 		{
 			yyVAL.expr_map = &ast.MapExpr{Keys: []ast.Expr{yyDollar[1].expr}, Values: []ast.Expr{yyDollar[3].expr}}
 		}
 	case 121:
 		yyDollar = yyS[yypt-6 : yypt+1]
-//line parser.go.y:795
+//line parser.go.y:809
 		{
 			if yyDollar[1].expr_map.Keys == nil {
 				yylex.Error("syntax error: unexpected ','")
@@ -2148,142 +2162,142 @@ yydefault:
 		}
 	case 122:
 		yyDollar = yyS[yypt-6 : yypt+1]
-//line parser.go.y:805
+//line parser.go.y:819
 		{
 			yyVAL.expr_slice = &ast.SliceExpr{Item: yyDollar[1].expr_ident, Begin: yyDollar[3].expr, End: yyDollar[5].expr}
 		}
 	case 123:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line parser.go.y:809
+//line parser.go.y:823
 		{
 			yyVAL.expr_slice = &ast.SliceExpr{Item: yyDollar[1].expr_ident, Begin: yyDollar[3].expr, End: nil}
 		}
 	case 124:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line parser.go.y:813
+//line parser.go.y:827
 		{
 			yyVAL.expr_slice = &ast.SliceExpr{Item: yyDollar[1].expr_ident, Begin: nil, End: yyDollar[4].expr}
 		}
 	case 125:
 		yyDollar = yyS[yypt-7 : yypt+1]
-//line parser.go.y:817
+//line parser.go.y:831
 		{
 			yyVAL.expr_slice = &ast.SliceExpr{Item: yyDollar[1].expr_ident, End: yyDollar[4].expr, Cap: yyDollar[6].expr}
 		}
 	case 126:
 		yyDollar = yyS[yypt-8 : yypt+1]
-//line parser.go.y:821
+//line parser.go.y:835
 		{
 			yyVAL.expr_slice = &ast.SliceExpr{Item: yyDollar[1].expr_ident, Begin: yyDollar[3].expr, End: yyDollar[5].expr, Cap: yyDollar[7].expr}
 		}
 	case 127:
 		yyDollar = yyS[yypt-6 : yypt+1]
-//line parser.go.y:825
+//line parser.go.y:839
 		{
 			yyVAL.expr_slice = &ast.SliceExpr{Item: yyDollar[1].expr, Begin: yyDollar[3].expr, End: yyDollar[5].expr}
 		}
 	case 128:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line parser.go.y:829
+//line parser.go.y:843
 		{
 			yyVAL.expr_slice = &ast.SliceExpr{Item: yyDollar[1].expr, Begin: yyDollar[3].expr, End: nil}
 		}
 	case 129:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line parser.go.y:833
+//line parser.go.y:847
 		{
 			yyVAL.expr_slice = &ast.SliceExpr{Item: yyDollar[1].expr, Begin: nil, End: yyDollar[4].expr}
 		}
 	case 130:
 		yyDollar = yyS[yypt-7 : yypt+1]
-//line parser.go.y:837
+//line parser.go.y:851
 		{
 			yyVAL.expr_slice = &ast.SliceExpr{Item: yyDollar[1].expr, End: yyDollar[4].expr, Cap: yyDollar[6].expr}
 		}
 	case 131:
 		yyDollar = yyS[yypt-8 : yypt+1]
-//line parser.go.y:841
+//line parser.go.y:855
 		{
 			yyVAL.expr_slice = &ast.SliceExpr{Item: yyDollar[1].expr, Begin: yyDollar[3].expr, End: yyDollar[5].expr, Cap: yyDollar[7].expr}
 		}
 	case 132:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line parser.go.y:847
+//line parser.go.y:861
 		{
 			yyVAL.expr_chan = &ast.ChanExpr{LHS: yyDollar[1].expr, RHS: yyDollar[3].expr}
 		}
 	case 133:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line parser.go.y:851
+//line parser.go.y:865
 		{
 			yyVAL.expr_chan = &ast.ChanExpr{RHS: yyDollar[2].expr}
 		}
 	case 134:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line parser.go.y:857
+//line parser.go.y:871
 		{
 			yyVAL.expr = &ast.UnaryExpr{Operator: "-", Expr: yyDollar[2].expr}
 			yyVAL.expr.SetPosition(yyDollar[2].expr.Position())
 		}
 	case 135:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line parser.go.y:862
+//line parser.go.y:876
 		{
 			yyVAL.expr = &ast.UnaryExpr{Operator: "!", Expr: yyDollar[2].expr}
 			yyVAL.expr.SetPosition(yyDollar[2].expr.Position())
 		}
 	case 136:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line parser.go.y:867
+//line parser.go.y:881
 		{
 			yyVAL.expr = &ast.UnaryExpr{Operator: "^", Expr: yyDollar[2].expr}
 			yyVAL.expr.SetPosition(yyDollar[2].expr.Position())
 		}
 	case 137:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line parser.go.y:872
+//line parser.go.y:886
 		{
 			yyVAL.expr = &ast.AddrExpr{Expr: yyDollar[2].expr}
 			yyVAL.expr.SetPosition(yyDollar[2].expr.Position())
 		}
 	case 138:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line parser.go.y:877
+//line parser.go.y:891
 		{
 			yyVAL.expr = &ast.DerefExpr{Expr: yyDollar[2].expr}
 			yyVAL.expr.SetPosition(yyDollar[2].expr.Position())
 		}
 	case 139:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line parser.go.y:884
+//line parser.go.y:898
 		{
 			yyVAL.expr = &ast.OpExpr{Op: yyDollar[1].expr}
 			yyVAL.expr.SetPosition(yyDollar[1].expr.Position())
 		}
 	case 140:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line parser.go.y:889
+//line parser.go.y:903
 		{
 			yyVAL.expr = &ast.OpExpr{Op: yyDollar[1].expr}
 			yyVAL.expr.SetPosition(yyDollar[1].expr.Position())
 		}
 	case 141:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line parser.go.y:894
+//line parser.go.y:908
 		{
 			yyVAL.expr = &ast.OpExpr{Op: yyDollar[1].expr}
 			yyVAL.expr.SetPosition(yyDollar[1].expr.Position())
 		}
 	case 142:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line parser.go.y:899
+//line parser.go.y:913
 		{
 			yyVAL.expr = &ast.OpExpr{Op: yyDollar[1].expr}
 			yyVAL.expr.SetPosition(yyDollar[1].expr.Position())
 		}
 	case 143:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line parser.go.y:906
+//line parser.go.y:920
 		{
 			rhs := &ast.OpExpr{Op: &ast.AddOperator{LHS: yyDollar[1].expr, Operator: "+", RHS: oneLiteral}}
 			rhs.Op.SetPosition(yyDollar[1].expr.Position())
@@ -2293,7 +2307,7 @@ yydefault:
 		}
 	case 144:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line parser.go.y:914
+//line parser.go.y:928
 		{
 			rhs := &ast.OpExpr{Op: &ast.AddOperator{LHS: yyDollar[1].expr, Operator: "-", RHS: oneLiteral}}
 			rhs.Op.SetPosition(yyDollar[1].expr.Position())
@@ -2303,7 +2317,7 @@ yydefault:
 		}
 	case 145:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line parser.go.y:922
+//line parser.go.y:936
 		{
 			rhs := &ast.OpExpr{Op: &ast.AddOperator{LHS: yyDollar[1].expr, Operator: "+", RHS: yyDollar[3].expr}}
 			rhs.Op.SetPosition(yyDollar[1].expr.Position())
@@ -2313,7 +2327,7 @@ yydefault:
 		}
 	case 146:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line parser.go.y:930
+//line parser.go.y:944
 		{
 			rhs := &ast.OpExpr{Op: &ast.AddOperator{LHS: yyDollar[1].expr, Operator: "-", RHS: yyDollar[3].expr}}
 			rhs.Op.SetPosition(yyDollar[1].expr.Position())
@@ -2323,7 +2337,7 @@ yydefault:
 		}
 	case 147:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line parser.go.y:938
+//line parser.go.y:952
 		{
 			rhs := &ast.OpExpr{Op: &ast.AddOperator{LHS: yyDollar[1].expr, Operator: "|", RHS: yyDollar[3].expr}}
 			rhs.Op.SetPosition(yyDollar[1].expr.Position())
@@ -2333,7 +2347,7 @@ yydefault:
 		}
 	case 148:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line parser.go.y:946
+//line parser.go.y:960
 		{
 			rhs := &ast.OpExpr{Op: &ast.MultiplyOperator{LHS: yyDollar[1].expr, Operator: "*", RHS: yyDollar[3].expr}}
 			rhs.Op.SetPosition(yyDollar[1].expr.Position())
@@ -2343,7 +2357,7 @@ yydefault:
 		}
 	case 149:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line parser.go.y:954
+//line parser.go.y:968
 		{
 			rhs := &ast.OpExpr{Op: &ast.MultiplyOperator{LHS: yyDollar[1].expr, Operator: "/", RHS: yyDollar[3].expr}}
 			rhs.Op.SetPosition(yyDollar[1].expr.Position())
@@ -2353,7 +2367,7 @@ yydefault:
 		}
 	case 150:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line parser.go.y:962
+//line parser.go.y:976
 		{
 			rhs := &ast.OpExpr{Op: &ast.MultiplyOperator{LHS: yyDollar[1].expr, Operator: "&", RHS: yyDollar[3].expr}}
 			rhs.Op.SetPosition(yyDollar[1].expr.Position())
@@ -2363,119 +2377,119 @@ yydefault:
 		}
 	case 151:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line parser.go.y:973
+//line parser.go.y:987
 		{
 			yyVAL.expr = &ast.MultiplyOperator{LHS: yyDollar[1].expr, Operator: "*", RHS: yyDollar[3].expr}
 			yyVAL.expr.SetPosition(yyDollar[1].expr.Position())
 		}
 	case 152:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line parser.go.y:978
+//line parser.go.y:992
 		{
 			yyVAL.expr = &ast.MultiplyOperator{LHS: yyDollar[1].expr, Operator: "/", RHS: yyDollar[3].expr}
 			yyVAL.expr.SetPosition(yyDollar[1].expr.Position())
 		}
 	case 153:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line parser.go.y:983
+//line parser.go.y:997
 		{
 			yyVAL.expr = &ast.MultiplyOperator{LHS: yyDollar[1].expr, Operator: "%", RHS: yyDollar[3].expr}
 			yyVAL.expr.SetPosition(yyDollar[1].expr.Position())
 		}
 	case 154:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line parser.go.y:988
+//line parser.go.y:1002
 		{
 			yyVAL.expr = &ast.MultiplyOperator{LHS: yyDollar[1].expr, Operator: "<<", RHS: yyDollar[3].expr}
 			yyVAL.expr.SetPosition(yyDollar[1].expr.Position())
 		}
 	case 155:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line parser.go.y:993
+//line parser.go.y:1007
 		{
 			yyVAL.expr = &ast.MultiplyOperator{LHS: yyDollar[1].expr, Operator: ">>", RHS: yyDollar[3].expr}
 			yyVAL.expr.SetPosition(yyDollar[1].expr.Position())
 		}
 	case 156:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line parser.go.y:998
+//line parser.go.y:1012
 		{
 			yyVAL.expr = &ast.MultiplyOperator{LHS: yyDollar[1].expr, Operator: "&", RHS: yyDollar[3].expr}
 			yyVAL.expr.SetPosition(yyDollar[1].expr.Position())
 		}
 	case 157:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line parser.go.y:1005
+//line parser.go.y:1019
 		{
 			yyVAL.expr = &ast.AddOperator{LHS: yyDollar[1].expr, Operator: "+", RHS: yyDollar[3].expr}
 			yyVAL.expr.SetPosition(yyDollar[1].expr.Position())
 		}
 	case 158:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line parser.go.y:1010
+//line parser.go.y:1024
 		{
 			yyVAL.expr = &ast.AddOperator{LHS: yyDollar[1].expr, Operator: "-", RHS: yyDollar[3].expr}
 			yyVAL.expr.SetPosition(yyDollar[1].expr.Position())
 		}
 	case 159:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line parser.go.y:1015
+//line parser.go.y:1029
 		{
 			yyVAL.expr = &ast.AddOperator{LHS: yyDollar[1].expr, Operator: "|", RHS: yyDollar[3].expr}
 			yyVAL.expr.SetPosition(yyDollar[1].expr.Position())
 		}
 	case 160:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line parser.go.y:1022
+//line parser.go.y:1036
 		{
 			yyVAL.expr = &ast.ComparisonOperator{LHS: yyDollar[1].expr, Operator: "==", RHS: yyDollar[3].expr}
 			yyVAL.expr.SetPosition(yyDollar[1].expr.Position())
 		}
 	case 161:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line parser.go.y:1027
+//line parser.go.y:1041
 		{
 			yyVAL.expr = &ast.ComparisonOperator{LHS: yyDollar[1].expr, Operator: "!=", RHS: yyDollar[3].expr}
 			yyVAL.expr.SetPosition(yyDollar[1].expr.Position())
 		}
 	case 162:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line parser.go.y:1032
+//line parser.go.y:1046
 		{
 			yyVAL.expr = &ast.ComparisonOperator{LHS: yyDollar[1].expr, Operator: "<", RHS: yyDollar[3].expr}
 			yyVAL.expr.SetPosition(yyDollar[1].expr.Position())
 		}
 	case 163:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line parser.go.y:1037
+//line parser.go.y:1051
 		{
 			yyVAL.expr = &ast.ComparisonOperator{LHS: yyDollar[1].expr, Operator: "<=", RHS: yyDollar[3].expr}
 			yyVAL.expr.SetPosition(yyDollar[1].expr.Position())
 		}
 	case 164:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line parser.go.y:1042
+//line parser.go.y:1056
 		{
 			yyVAL.expr = &ast.ComparisonOperator{LHS: yyDollar[1].expr, Operator: ">", RHS: yyDollar[3].expr}
 			yyVAL.expr.SetPosition(yyDollar[1].expr.Position())
 		}
 	case 165:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line parser.go.y:1047
+//line parser.go.y:1061
 		{
 			yyVAL.expr = &ast.ComparisonOperator{LHS: yyDollar[1].expr, Operator: ">=", RHS: yyDollar[3].expr}
 			yyVAL.expr.SetPosition(yyDollar[1].expr.Position())
 		}
 	case 166:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line parser.go.y:1054
+//line parser.go.y:1068
 		{
 			yyVAL.expr = &ast.BinaryOperator{LHS: yyDollar[1].expr, Operator: "&&", RHS: yyDollar[3].expr}
 			yyVAL.expr.SetPosition(yyDollar[1].expr.Position())
 		}
 	case 167:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line parser.go.y:1059
+//line parser.go.y:1073
 		{
 			yyVAL.expr = &ast.BinaryOperator{LHS: yyDollar[1].expr, Operator: "||", RHS: yyDollar[3].expr}
 			yyVAL.expr.SetPosition(yyDollar[1].expr.Position())

--- a/parser/parser.go.y
+++ b/parser/parser.go.y
@@ -270,16 +270,26 @@ stmt_lets :
 	}
 	| exprs '=' exprs
 	{
-		if len($1) == 2 && len($3) == 1 {
-			if _, ok := $3[0].(*ast.ItemExpr); ok {
-				$$ = &ast.LetMapItemStmt{LHSS: $1, RHS: $3[0]}
+		if len($1) < 1 {
+			yylex.Error("missing expressions on left side of '='")
+			$$ = &ast.LetsStmt{LHSS: $1, RHSS: $3}
+			$$.SetPosition($<tok>2.Position())
+		} else if len($3) < 1 {
+			yylex.Error("missing expressions on right side of '='")
+			$$ = &ast.LetsStmt{LHSS: $1, RHSS: $3}
+			$$.SetPosition($1[0].Position())
+		} else {
+			if len($1) == 2 && len($3) == 1 {
+				if _, ok := $3[0].(*ast.ItemExpr); ok {
+					$$ = &ast.LetMapItemStmt{LHSS: $1, RHS: $3[0]}
+				} else {
+					$$ = &ast.LetsStmt{LHSS: $1, RHSS: $3}
+				}
 			} else {
 				$$ = &ast.LetsStmt{LHSS: $1, RHSS: $3}
 			}
-		} else {
-			$$ = &ast.LetsStmt{LHSS: $1, RHSS: $3}
+			$$.SetPosition($1[0].Position())
 		}
-		$$.SetPosition($1[0].Position())
 	}
 	| expr EQOPCHAN expr
 	{
@@ -296,6 +306,10 @@ stmt_lets :
 			yylex.Error("missing expressions on left side of channel operator")
 			$$ = &ast.ChanStmt{RHS: $3}
 			$$.SetPosition($2.Position())
+		} else {
+			yylex.Error("too many expressions on left side of channel operator")
+			$$ = &ast.ChanStmt{RHS: $3}
+			$$.SetPosition($1[0].Position())
 		}
 	}
 

--- a/parser/y.output
+++ b/parser/y.output
@@ -1,0 +1,12196 @@
+
+0: shift/reduce conflict (shift 5(0), red'n 168(0)) on ';'
+0: shift/reduce conflict (shift 8(0), red'n 168(0)) on '\n'
+state 0
+	$accept: .compstmt $end 
+	opt_term: .    (168)
+
+	';'  shift 5
+	'\n'  shift 8
+	.  reduce 168 (src line 1079)
+
+	compstmt  goto 1
+	stmts  goto 3
+	opt_term  goto 2
+	term  goto 4
+	newlines  goto 6
+	newline  goto 7
+
+state 1
+	$accept:  compstmt.$end 
+
+	$end  accept
+	.  error
+
+
+ 2: reduce/reduce conflict  (red'ns 1 and 5) on $end
+ 2: reduce/reduce conflict  (red'ns 1 and 5) on CASE
+ 2: reduce/reduce conflict  (red'ns 1 and 5) on DEFAULT
+ 2: reduce/reduce conflict  (red'ns 1 and 5) on '}'
+ 2: reduce/reduce conflict  (red'ns 1 and 5) on '\n'
+state 2
+	compstmt:  opt_term.    (1)
+	stmts:  opt_term.stmt 
+	stmt: .    (5)
+	exprs: .    (57)
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	RETURN  shift 13
+	VAR  shift 48
+	THROW  shift 14
+	IF  shift 26
+	FOR  shift 27
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MODULE  shift 15
+	TRY  shift 16
+	BREAK  shift 11
+	CONTINUE  shift 12
+	SWITCH  shift 28
+	GO  shift 17
+	MAKE  shift 40
+	OPCHAN  shift 57
+	EQOPCHAN  reduce 57 (src line 455)
+	LEN  shift 37
+	DELETE  shift 18
+	CLOSE  shift 19
+	MAP  shift 41
+	IMPORT  shift 38
+	'='  reduce 57 (src line 455)
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	','  reduce 57 (src line 455)
+	';'  reduce 5 (src line 141)
+	'['  shift 32
+	'!'  shift 58
+	.  reduce 1 (src line 106)
+
+	stmt  goto 9
+	stmt_var_or_lets  goto 10
+	stmt_var  goto 24
+	stmt_lets  goto 25
+	stmt_if  goto 20
+	stmt_for  goto 21
+	stmt_switch  goto 22
+	exprs  goto 49
+	expr  goto 23
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+3: shift/reduce conflict (shift 8(0), red'n 168(0)) on '\n'
+state 3
+	compstmt:  stmts.opt_term 
+	stmts:  stmts.term stmt 
+	opt_term: .    (168)
+
+	';'  shift 5
+	'\n'  shift 8
+	.  reduce 168 (src line 1079)
+
+	opt_term  goto 66
+	term  goto 67
+	newlines  goto 6
+	newline  goto 7
+
+state 4
+	opt_term:  term.    (169)
+
+	.  reduce 169 (src line 1081)
+
+
+5: shift/reduce conflict (shift 8(0), red'n 172(0)) on '\n'
+state 5
+	term:  ';'.newlines 
+	term:  ';'.    (172)
+
+	'\n'  shift 8
+	.  reduce 172 (src line 1086)
+
+	newlines  goto 68
+	newline  goto 7
+
+6: shift/reduce conflict (shift 8(0), red'n 171(0)) on '\n'
+state 6
+	term:  newlines.    (171)
+	newlines:  newlines.newline 
+
+	'\n'  shift 8
+	.  reduce 171 (src line 1085)
+
+	newline  goto 69
+
+state 7
+	newlines:  newline.    (175)
+
+	.  reduce 175 (src line 1092)
+
+
+state 8
+	newline:  '\n'.    (177)
+
+	.  reduce 177 (src line 1096)
+
+
+state 9
+	stmts:  opt_term stmt.    (3)
+
+	.  reduce 3 (src line 116)
+
+
+state 10
+	stmt:  stmt_var_or_lets.    (6)
+
+	.  reduce 6 (src line 146)
+
+
+state 11
+	stmt:  BREAK.    (7)
+
+	.  reduce 7 (src line 150)
+
+
+state 12
+	stmt:  CONTINUE.    (8)
+
+	.  reduce 8 (src line 155)
+
+
+state 13
+	stmt:  RETURN.exprs 
+	exprs: .    (57)
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  reduce 57 (src line 455)
+
+	exprs  goto 70
+	expr  goto 71
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 14
+	stmt:  THROW.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 72
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 15
+	stmt:  MODULE.IDENT '{' compstmt '}' 
+
+	IDENT  shift 73
+	.  error
+
+
+state 16
+	stmt:  TRY.'{' compstmt '}' CATCH IDENT '{' compstmt '}' FINALLY '{' compstmt '}' 
+	stmt:  TRY.'{' compstmt '}' CATCH '{' compstmt '}' FINALLY '{' compstmt '}' 
+	stmt:  TRY.'{' compstmt '}' CATCH IDENT '{' compstmt '}' 
+	stmt:  TRY.'{' compstmt '}' CATCH '{' compstmt '}' 
+
+	'{'  shift 74
+	.  error
+
+
+state 17
+	stmt:  GO.IDENT '(' exprs VARARG ')' 
+	stmt:  GO.IDENT '(' exprs ')' 
+	stmt:  GO.expr '(' exprs VARARG ')' 
+	stmt:  GO.expr '(' exprs ')' 
+
+	IDENT  shift 75
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 76
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 18
+	stmt:  DELETE.'(' expr ')' 
+	stmt:  DELETE.'(' expr ',' expr ')' 
+
+	'('  shift 77
+	.  error
+
+
+state 19
+	stmt:  CLOSE.'(' expr ')' 
+
+	'('  shift 78
+	.  error
+
+
+state 20
+	stmt:  stmt_if.    (23)
+	stmt_if:  stmt_if.ELSE IF expr '{' compstmt '}' 
+	stmt_if:  stmt_if.ELSE '{' compstmt '}' 
+
+	ELSE  shift 79
+	.  reduce 23 (src line 230)
+
+
+state 21
+	stmt:  stmt_for.    (24)
+
+	.  reduce 24 (src line 234)
+
+
+state 22
+	stmt:  stmt_switch.    (25)
+
+	.  reduce 25 (src line 238)
+
+
+23: shift/reduce conflict (shift 81(2), red'n 58(0)) on EQOPCHAN
+23: shift/reduce conflict (shift 80(2), red'n 58(0)) on '='
+state 23
+	stmt:  expr.    (26)
+	stmt_lets:  expr.'=' expr 
+	stmt_lets:  expr.EQOPCHAN expr 
+	exprs:  expr.    (58)
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	EQOPCHAN  shift 81
+	'='  shift 80
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	','  reduce 58 (src line 460)
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 26 (src line 242)
+
+
+state 24
+	stmt_var_or_lets:  stmt_var.    (27)
+
+	.  reduce 27 (src line 248)
+
+
+state 25
+	stmt_var_or_lets:  stmt_lets.    (28)
+
+	.  reduce 28 (src line 253)
+
+
+state 26
+	stmt_if:  IF.expr '{' compstmt '}' 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 114
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+ 27: reduce/reduce conflict  (red'ns 95 and 57) on ','
+state 27
+	stmt_for:  FOR.'{' compstmt '}' 
+	stmt_for:  FOR.expr_idents IN expr '{' compstmt '}' 
+	stmt_for:  FOR.expr '{' compstmt '}' 
+	stmt_for:  FOR.';' ';' '{' compstmt '}' 
+	stmt_for:  FOR.';' ';' expr '{' compstmt '}' 
+	stmt_for:  FOR.';' expr ';' '{' compstmt '}' 
+	stmt_for:  FOR.';' expr ';' expr '{' compstmt '}' 
+	stmt_for:  FOR.stmt_var_or_lets ';' ';' '{' compstmt '}' 
+	stmt_for:  FOR.stmt_var_or_lets ';' ';' expr '{' compstmt '}' 
+	stmt_for:  FOR.stmt_var_or_lets ';' expr ';' '{' compstmt '}' 
+	stmt_for:  FOR.stmt_var_or_lets ';' expr ';' expr '{' compstmt '}' 
+	expr_idents: .    (95)
+	exprs: .    (57)
+
+	IDENT  shift 120
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	VAR  shift 48
+	IN  reduce 95 (src line 644)
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 115
+	'('  shift 34
+	';'  shift 118
+	'['  shift 32
+	'!'  shift 58
+	.  reduce 57 (src line 455)
+
+	stmt_var_or_lets  goto 119
+	stmt_var  goto 24
+	stmt_lets  goto 25
+	exprs  goto 49
+	expr  goto 117
+	expr_idents  goto 116
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 28
+	stmt_switch:  SWITCH.expr '{' opt_newlines stmt_switch_cases opt_newlines '}' 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 121
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 29
+	expr:  expr_member_or_ident.    (61)
+
+	.  reduce 61 (src line 479)
+
+
+state 30
+	expr:  expr_literals.    (62)
+
+	.  reduce 62 (src line 484)
+
+
+state 31
+	expr:  FUNC.'(' expr_idents ')' '{' compstmt '}' 
+	expr:  FUNC.'(' expr_idents VARARG ')' '{' compstmt '}' 
+	expr:  FUNC.IDENT '(' expr_idents ')' '{' compstmt '}' 
+	expr:  FUNC.IDENT '(' expr_idents VARARG ')' '{' compstmt '}' 
+
+	IDENT  shift 123
+	'('  shift 122
+	.  error
+
+
+32: shift/reduce conflict (shift 124(0), red'n 173(0)) on ']'
+32: shift/reduce conflict (shift 8(0), red'n 173(0)) on '\n'
+state 32
+	expr:  '['.']' 
+	expr:  '['.opt_newlines exprs opt_comma_newlines ']' 
+	slice_count:  '['.']' 
+	slice_count:  '['.']' slice_count 
+	opt_newlines: .    (173)
+
+	']'  shift 124
+	'\n'  shift 8
+	.  reduce 173 (src line 1088)
+
+	opt_newlines  goto 125
+	newlines  goto 126
+	newline  goto 7
+
+state 33
+	expr:  slice_count.type_data '{' opt_newlines exprs opt_comma_newlines '}' 
+
+	IDENT  shift 128
+	CHAN  shift 132
+	STRUCT  shift 133
+	MAP  shift 131
+	'*'  shift 129
+	'['  shift 134
+	.  error
+
+	type_data  goto 127
+	slice_count  goto 130
+
+state 34
+	expr:  '('.expr ')' 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 135
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+35: shift/reduce conflict (shift 136(0), red'n 112(0)) on '('
+state 35
+	expr:  IDENT.'(' exprs VARARG ')' 
+	expr:  IDENT.'(' exprs ')' 
+	expr_ident:  IDENT.    (112)
+
+	'('  shift 136
+	.  reduce 112 (src line 752)
+
+
+36: shift/reduce conflict (shift 137(0), red'n 110(0)) on '['
+state 36
+	expr:  expr_ident.'[' expr ']' 
+	expr_member_or_ident:  expr_ident.    (110)
+	expr_slice:  expr_ident.'[' expr ':' expr ']' 
+	expr_slice:  expr_ident.'[' expr ':' ']' 
+	expr_slice:  expr_ident.'[' ':' expr ']' 
+	expr_slice:  expr_ident.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr_ident.'[' expr ':' expr ':' expr ']' 
+
+	'['  shift 137
+	.  reduce 110 (src line 740)
+
+
+state 37
+	expr:  LEN.'(' expr ')' 
+
+	'('  shift 138
+	.  error
+
+
+state 38
+	expr:  IMPORT.'(' expr ')' 
+
+	'('  shift 139
+	.  error
+
+
+state 39
+	expr:  NEW.'(' type_data ')' 
+
+	'('  shift 140
+	.  error
+
+
+state 40
+	expr:  MAKE.'(' type_data ')' 
+	expr:  MAKE.'(' type_data ',' expr ')' 
+	expr:  MAKE.'(' type_data ',' expr ',' expr ')' 
+	expr:  MAKE.'(' TYPE IDENT ',' expr ')' 
+
+	'('  shift 141
+	.  error
+
+
+state 41
+	expr:  MAP.'{' opt_newlines expr_map opt_comma_newlines '}' 
+	expr:  MAP.'[' type_data ']' type_data '{' opt_newlines expr_map opt_comma_newlines '}' 
+
+	'{'  shift 142
+	'['  shift 143
+	.  error
+
+
+42: shift/reduce conflict (shift 8(0), red'n 173(0)) on '\n'
+state 42
+	expr:  '{'.opt_newlines expr_map opt_comma_newlines '}' 
+	opt_newlines: .    (173)
+
+	'\n'  shift 8
+	.  reduce 173 (src line 1088)
+
+	opt_newlines  goto 144
+	newlines  goto 126
+	newline  goto 7
+
+state 43
+	expr:  expr_slice.    (90)
+
+	.  reduce 90 (src line 630)
+
+
+state 44
+	expr:  expr_chan.    (91)
+
+	.  reduce 91 (src line 635)
+
+
+state 45
+	expr:  expr_unary.    (92)
+
+	.  reduce 92 (src line 640)
+
+
+state 46
+	expr:  expr_binary.    (93)
+
+	.  reduce 93 (src line 641)
+
+
+state 47
+	expr:  expr_lets.    (94)
+
+	.  reduce 94 (src line 642)
+
+
+state 48
+	stmt_var:  VAR.expr_idents '=' exprs 
+	expr_idents: .    (95)
+
+	IDENT  shift 146
+	.  reduce 95 (src line 644)
+
+	expr_idents  goto 145
+
+state 49
+	stmt_lets:  exprs.'=' exprs 
+	stmt_lets:  exprs.EQOPCHAN expr 
+	exprs:  exprs.',' opt_newlines expr 
+	exprs:  exprs.',' opt_newlines expr_ident 
+
+	EQOPCHAN  shift 148
+	'='  shift 147
+	','  shift 149
+	.  error
+
+
+state 50
+	expr_member_or_ident:  expr_member.    (109)
+
+	.  reduce 109 (src line 735)
+
+
+state 51
+	expr_literals:  '-'.NUMBER 
+	expr_unary:  '-'.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 150
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 151
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 52
+	expr_literals:  NUMBER.    (114)
+
+	.  reduce 114 (src line 769)
+
+
+state 53
+	expr_literals:  STRING.    (115)
+
+	.  reduce 115 (src line 778)
+
+
+state 54
+	expr_literals:  TRUE.    (116)
+
+	.  reduce 116 (src line 783)
+
+
+state 55
+	expr_literals:  FALSE.    (117)
+
+	.  reduce 117 (src line 788)
+
+
+state 56
+	expr_literals:  NIL.    (118)
+
+	.  reduce 118 (src line 793)
+
+
+state 57
+	expr_chan:  OPCHAN.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 152
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 58
+	expr_unary:  '!'.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 153
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 59
+	expr_unary:  '^'.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 154
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 60
+	expr_unary:  '&'.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 155
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 61
+	expr_unary:  '*'.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 156
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 62
+	expr_binary:  op_multiply.    (139)
+
+	.  reduce 139 (src line 896)
+
+
+state 63
+	expr_binary:  op_add.    (140)
+
+	.  reduce 140 (src line 902)
+
+
+state 64
+	expr_binary:  op_comparison.    (141)
+
+	.  reduce 141 (src line 907)
+
+
+state 65
+	expr_binary:  op_binary.    (142)
+
+	.  reduce 142 (src line 912)
+
+
+state 66
+	compstmt:  stmts opt_term.    (2)
+
+	.  reduce 2 (src line 111)
+
+
+ 67: reduce/reduce conflict  (red'ns 169 and 5) on $end
+ 67: reduce/reduce conflict  (red'ns 169 and 5) on CASE
+ 67: reduce/reduce conflict  (red'ns 169 and 5) on DEFAULT
+ 67: reduce/reduce conflict  (red'ns 169 and 5) on '}'
+ 67: reduce/reduce conflict  (red'ns 169 and 5) on '\n'
+state 67
+	stmts:  stmts term.stmt 
+	opt_term:  term.    (169)
+	stmt: .    (5)
+	exprs: .    (57)
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	RETURN  shift 13
+	VAR  shift 48
+	THROW  shift 14
+	IF  shift 26
+	FOR  shift 27
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MODULE  shift 15
+	TRY  shift 16
+	BREAK  shift 11
+	CONTINUE  shift 12
+	SWITCH  shift 28
+	GO  shift 17
+	MAKE  shift 40
+	OPCHAN  shift 57
+	EQOPCHAN  reduce 57 (src line 455)
+	LEN  shift 37
+	DELETE  shift 18
+	CLOSE  shift 19
+	MAP  shift 41
+	IMPORT  shift 38
+	'='  reduce 57 (src line 455)
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	','  reduce 57 (src line 455)
+	'['  shift 32
+	'!'  shift 58
+	.  reduce 5 (src line 141)
+
+	stmt  goto 157
+	stmt_var_or_lets  goto 10
+	stmt_var  goto 24
+	stmt_lets  goto 25
+	stmt_if  goto 20
+	stmt_for  goto 21
+	stmt_switch  goto 22
+	exprs  goto 49
+	expr  goto 23
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+68: shift/reduce conflict (shift 8(0), red'n 170(0)) on '\n'
+state 68
+	term:  ';' newlines.    (170)
+	newlines:  newlines.newline 
+
+	'\n'  shift 8
+	.  reduce 170 (src line 1083)
+
+	newline  goto 69
+
+state 69
+	newlines:  newlines newline.    (176)
+
+	.  reduce 176 (src line 1094)
+
+
+state 70
+	stmt:  RETURN exprs.    (9)
+	exprs:  exprs.',' opt_newlines expr 
+	exprs:  exprs.',' opt_newlines expr_ident 
+
+	','  shift 149
+	.  reduce 9 (src line 160)
+
+
+state 71
+	exprs:  expr.    (58)
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 58 (src line 460)
+
+
+state 72
+	stmt:  THROW expr.    (10)
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 10 (src line 165)
+
+
+state 73
+	stmt:  MODULE IDENT.'{' compstmt '}' 
+
+	'{'  shift 158
+	.  error
+
+
+74: shift/reduce conflict (shift 5(0), red'n 168(0)) on ';'
+74: shift/reduce conflict (shift 8(0), red'n 168(0)) on '\n'
+state 74
+	stmt:  TRY '{'.compstmt '}' CATCH IDENT '{' compstmt '}' FINALLY '{' compstmt '}' 
+	stmt:  TRY '{'.compstmt '}' CATCH '{' compstmt '}' FINALLY '{' compstmt '}' 
+	stmt:  TRY '{'.compstmt '}' CATCH IDENT '{' compstmt '}' 
+	stmt:  TRY '{'.compstmt '}' CATCH '{' compstmt '}' 
+	opt_term: .    (168)
+
+	';'  shift 5
+	'\n'  shift 8
+	.  reduce 168 (src line 1079)
+
+	compstmt  goto 159
+	stmts  goto 3
+	opt_term  goto 2
+	term  goto 4
+	newlines  goto 6
+	newline  goto 7
+
+75: shift/reduce conflict (shift 160(0), red'n 112(0)) on '('
+state 75
+	stmt:  GO IDENT.'(' exprs VARARG ')' 
+	stmt:  GO IDENT.'(' exprs ')' 
+	expr:  IDENT.'(' exprs VARARG ')' 
+	expr:  IDENT.'(' exprs ')' 
+	expr_ident:  IDENT.    (112)
+
+	'('  shift 160
+	.  reduce 112 (src line 752)
+
+
+state 76
+	stmt:  GO expr.'(' exprs VARARG ')' 
+	stmt:  GO expr.'(' exprs ')' 
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 161
+	'['  shift 85
+	'.'  shift 87
+	.  error
+
+
+state 77
+	stmt:  DELETE '('.expr ')' 
+	stmt:  DELETE '('.expr ',' expr ')' 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 162
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 78
+	stmt:  CLOSE '('.expr ')' 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 163
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 79
+	stmt_if:  stmt_if ELSE.IF expr '{' compstmt '}' 
+	stmt_if:  stmt_if ELSE.'{' compstmt '}' 
+
+	IF  shift 164
+	'{'  shift 165
+	.  error
+
+
+state 80
+	stmt_lets:  expr '='.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 166
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 81
+	stmt_lets:  expr EQOPCHAN.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 167
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 82
+	expr:  expr '?'.expr ':' expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 168
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 83
+	expr:  expr NILCOALESCE.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 169
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 84
+	expr:  expr '('.exprs VARARG ')' 
+	expr:  expr '('.exprs ')' 
+	exprs: .    (57)
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  reduce 57 (src line 455)
+
+	exprs  goto 170
+	expr  goto 71
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 85
+	expr:  expr '['.expr ']' 
+	expr_slice:  expr '['.expr ':' expr ']' 
+	expr_slice:  expr '['.expr ':' ']' 
+	expr_slice:  expr '['.':' expr ']' 
+	expr_slice:  expr '['.':' expr ':' expr ']' 
+	expr_slice:  expr '['.expr ':' expr ':' expr ']' 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	':'  shift 172
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 171
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 86
+	expr:  expr IN.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 173
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 87
+	expr_member:  expr '.'.IDENT 
+
+	IDENT  shift 174
+	.  error
+
+
+state 88
+	expr_chan:  expr OPCHAN.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 175
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 89
+	expr_lets:  expr PLUSPLUS.    (143)
+
+	.  reduce 143 (src line 918)
+
+
+state 90
+	expr_lets:  expr MINUSMINUS.    (144)
+
+	.  reduce 144 (src line 927)
+
+
+state 91
+	expr_lets:  expr PLUSEQ.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 176
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 92
+	expr_lets:  expr MINUSEQ.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 177
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 93
+	expr_lets:  expr OREQ.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 178
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 94
+	expr_lets:  expr MULEQ.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 179
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 95
+	expr_lets:  expr DIVEQ.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 180
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 96
+	expr_lets:  expr ANDEQ.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 181
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 97
+	op_multiply:  expr '*'.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 182
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 98
+	op_multiply:  expr '/'.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 183
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 99
+	op_multiply:  expr '%'.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 184
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 100
+	op_multiply:  expr SHIFTLEFT.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 185
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 101
+	op_multiply:  expr SHIFTRIGHT.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 186
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 102
+	op_multiply:  expr '&'.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 187
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 103
+	op_add:  expr '+'.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 188
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 104
+	op_add:  expr '-'.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 189
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 105
+	op_add:  expr '|'.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 190
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 106
+	op_comparison:  expr EQEQ.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 191
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 107
+	op_comparison:  expr NEQ.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 192
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 108
+	op_comparison:  expr '<'.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 193
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 109
+	op_comparison:  expr LE.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 194
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 110
+	op_comparison:  expr '>'.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 195
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 111
+	op_comparison:  expr GE.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 196
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 112
+	op_binary:  expr ANDAND.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 197
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 113
+	op_binary:  expr OROR.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 198
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 114
+	stmt_if:  IF expr.'{' compstmt '}' 
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'{'  shift 199
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  error
+
+
+115: shift/reduce conflict (shift 8(0), red'n 173(0)) on '\n'
+ 115: reduce/reduce conflict  (red'ns 173 and 168) on IDENT
+ 115: reduce/reduce conflict  (red'ns 173 and 168) on NUMBER
+ 115: reduce/reduce conflict  (red'ns 173 and 168) on STRING
+ 115: reduce/reduce conflict  (red'ns 173 and 168) on FUNC
+ 115: reduce/reduce conflict  (red'ns 173 and 168) on NEW
+ 115: reduce/reduce conflict  (red'ns 173 and 168) on TRUE
+ 115: reduce/reduce conflict  (red'ns 173 and 168) on FALSE
+ 115: reduce/reduce conflict  (red'ns 173 and 168) on NIL
+ 115: reduce/reduce conflict  (red'ns 173 and 168) on MAKE
+ 115: reduce/reduce conflict  (red'ns 173 and 168) on OPCHAN
+ 115: reduce/reduce conflict  (red'ns 173 and 168) on LEN
+ 115: reduce/reduce conflict  (red'ns 173 and 168) on MAP
+ 115: reduce/reduce conflict  (red'ns 173 and 168) on IMPORT
+ 115: reduce/reduce conflict  (red'ns 173 and 168) on '-'
+ 115: reduce/reduce conflict  (red'ns 173 and 168) on '^'
+ 115: reduce/reduce conflict  (red'ns 173 and 168) on '*'
+ 115: reduce/reduce conflict  (red'ns 173 and 168) on '&'
+ 115: reduce/reduce conflict  (red'ns 173 and 168) on '{'
+ 115: reduce/reduce conflict  (red'ns 173 and 168) on '}'
+ 115: reduce/reduce conflict  (red'ns 173 and 168) on '('
+ 115: reduce/reduce conflict  (red'ns 173 and 168) on ','
+115: shift/reduce conflict (shift 5(0), red'n 168(0)) on ';'
+ 115: reduce/reduce conflict  (red'ns 173 and 168) on '['
+ 115: reduce/reduce conflict  (red'ns 173 and 168) on '!'
+115: shift/reduce conflict (shift 8(0), red'n 168(0)) on '\n'
+state 115
+	stmt_for:  FOR '{'.compstmt '}' 
+	expr:  '{'.opt_newlines expr_map opt_comma_newlines '}' 
+	opt_newlines: .    (173)
+	opt_term: .    (168)
+
+	';'  shift 5
+	'\n'  shift 8
+	.  reduce 168 (src line 1079)
+
+	compstmt  goto 200
+	stmts  goto 3
+	opt_term  goto 2
+	term  goto 4
+	opt_newlines  goto 144
+	newlines  goto 201
+	newline  goto 7
+
+state 116
+	stmt_for:  FOR expr_idents.IN expr '{' compstmt '}' 
+	expr_idents:  expr_idents.',' opt_newlines IDENT 
+
+	IN  shift 202
+	','  shift 203
+	.  error
+
+
+117: shift/reduce conflict (shift 81(2), red'n 58(0)) on EQOPCHAN
+117: shift/reduce conflict (shift 80(2), red'n 58(0)) on '='
+state 117
+	stmt_lets:  expr.'=' expr 
+	stmt_lets:  expr.EQOPCHAN expr 
+	stmt_for:  FOR expr.'{' compstmt '}' 
+	exprs:  expr.    (58)
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	EQOPCHAN  shift 81
+	'='  shift 80
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'{'  shift 204
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 58 (src line 460)
+
+
+state 118
+	stmt_for:  FOR ';'.';' '{' compstmt '}' 
+	stmt_for:  FOR ';'.';' expr '{' compstmt '}' 
+	stmt_for:  FOR ';'.expr ';' '{' compstmt '}' 
+	stmt_for:  FOR ';'.expr ';' expr '{' compstmt '}' 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	';'  shift 205
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 206
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 119
+	stmt_for:  FOR stmt_var_or_lets.';' ';' '{' compstmt '}' 
+	stmt_for:  FOR stmt_var_or_lets.';' ';' expr '{' compstmt '}' 
+	stmt_for:  FOR stmt_var_or_lets.';' expr ';' '{' compstmt '}' 
+	stmt_for:  FOR stmt_var_or_lets.';' expr ';' expr '{' compstmt '}' 
+
+	';'  shift 207
+	.  error
+
+
+ 120: reduce/reduce conflict  (red'ns 96 and 112) on IN
+120: shift/reduce conflict (shift 136(0), red'n 112(0)) on '('
+ 120: reduce/reduce conflict  (red'ns 96 and 112) on ','
+state 120
+	expr:  IDENT.'(' exprs VARARG ')' 
+	expr:  IDENT.'(' exprs ')' 
+	expr_idents:  IDENT.    (96)
+	expr_ident:  IDENT.    (112)
+
+	IN  reduce 96 (src line 648)
+	'('  shift 136
+	','  reduce 96 (src line 648)
+	.  reduce 112 (src line 752)
+
+
+state 121
+	stmt_switch:  SWITCH expr.'{' opt_newlines stmt_switch_cases opt_newlines '}' 
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'{'  shift 208
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  error
+
+
+state 122
+	expr:  FUNC '('.expr_idents ')' '{' compstmt '}' 
+	expr:  FUNC '('.expr_idents VARARG ')' '{' compstmt '}' 
+	expr_idents: .    (95)
+
+	IDENT  shift 146
+	.  reduce 95 (src line 644)
+
+	expr_idents  goto 209
+
+state 123
+	expr:  FUNC IDENT.'(' expr_idents ')' '{' compstmt '}' 
+	expr:  FUNC IDENT.'(' expr_idents VARARG ')' '{' compstmt '}' 
+
+	'('  shift 210
+	.  error
+
+
+124: shift/reduce conflict (shift 134(0), red'n 69(0)) on '['
+ 124: reduce/reduce conflict  (red'ns 69 and 107) on '*'
+124: shift/reduce conflict (shift 134(0), red'n 107(0)) on '['
+state 124
+	expr:  '[' ']'.    (69)
+	slice_count:  '[' ']'.    (107)
+	slice_count:  '[' ']'.slice_count 
+
+	IDENT  reduce 107 (src line 725)
+	CHAN  reduce 107 (src line 725)
+	STRUCT  reduce 107 (src line 725)
+	MAP  reduce 107 (src line 725)
+	'['  shift 134
+	.  reduce 69 (src line 518)
+
+	slice_count  goto 211
+
+state 125
+	expr:  '[' opt_newlines.exprs opt_comma_newlines ']' 
+	exprs: .    (57)
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  reduce 57 (src line 455)
+
+	exprs  goto 212
+	expr  goto 71
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+126: shift/reduce conflict (shift 8(0), red'n 174(0)) on '\n'
+state 126
+	opt_newlines:  newlines.    (174)
+	newlines:  newlines.newline 
+
+	'\n'  shift 8
+	.  reduce 174 (src line 1090)
+
+	newline  goto 69
+
+state 127
+	expr:  slice_count type_data.'{' opt_newlines exprs opt_comma_newlines '}' 
+	type_data:  type_data.'.' IDENT 
+
+	'{'  shift 213
+	'.'  shift 214
+	.  error
+
+
+state 128
+	type_data:  IDENT.    (98)
+
+	.  reduce 98 (src line 660)
+
+
+state 129
+	type_data:  '*'.type_data 
+
+	IDENT  shift 128
+	CHAN  shift 132
+	STRUCT  shift 133
+	MAP  shift 131
+	'*'  shift 129
+	'['  shift 134
+	.  error
+
+	type_data  goto 215
+	slice_count  goto 130
+
+state 130
+	type_data:  slice_count.type_data 
+
+	IDENT  shift 128
+	CHAN  shift 132
+	STRUCT  shift 133
+	MAP  shift 131
+	'*'  shift 129
+	'['  shift 134
+	.  error
+
+	type_data  goto 216
+	slice_count  goto 130
+
+state 131
+	type_data:  MAP.'[' type_data ']' type_data 
+
+	'['  shift 217
+	.  error
+
+
+state 132
+	type_data:  CHAN.type_data 
+
+	IDENT  shift 128
+	CHAN  shift 132
+	STRUCT  shift 133
+	MAP  shift 131
+	'*'  shift 129
+	'['  shift 134
+	.  error
+
+	type_data  goto 218
+	slice_count  goto 130
+
+state 133
+	type_data:  STRUCT.'{' opt_newlines type_data_struct opt_newlines '}' 
+
+	'{'  shift 219
+	.  error
+
+
+state 134
+	slice_count:  '['.']' 
+	slice_count:  '['.']' slice_count 
+
+	']'  shift 220
+	.  error
+
+
+state 135
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  '(' expr.')' 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	')'  shift 221
+	'['  shift 85
+	'.'  shift 87
+	.  error
+
+
+state 136
+	expr:  IDENT '('.exprs VARARG ')' 
+	expr:  IDENT '('.exprs ')' 
+	exprs: .    (57)
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  reduce 57 (src line 455)
+
+	exprs  goto 222
+	expr  goto 71
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 137
+	expr:  expr_ident '['.expr ']' 
+	expr_slice:  expr_ident '['.expr ':' expr ']' 
+	expr_slice:  expr_ident '['.expr ':' ']' 
+	expr_slice:  expr_ident '['.':' expr ']' 
+	expr_slice:  expr_ident '['.':' expr ':' expr ']' 
+	expr_slice:  expr_ident '['.expr ':' expr ':' expr ']' 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	':'  shift 224
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 223
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 138
+	expr:  LEN '('.expr ')' 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 225
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 139
+	expr:  IMPORT '('.expr ')' 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 226
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 140
+	expr:  NEW '('.type_data ')' 
+
+	IDENT  shift 128
+	CHAN  shift 132
+	STRUCT  shift 133
+	MAP  shift 131
+	'*'  shift 129
+	'['  shift 134
+	.  error
+
+	type_data  goto 227
+	slice_count  goto 130
+
+state 141
+	expr:  MAKE '('.type_data ')' 
+	expr:  MAKE '('.type_data ',' expr ')' 
+	expr:  MAKE '('.type_data ',' expr ',' expr ')' 
+	expr:  MAKE '('.TYPE IDENT ',' expr ')' 
+
+	IDENT  shift 128
+	CHAN  shift 132
+	STRUCT  shift 133
+	TYPE  shift 229
+	MAP  shift 131
+	'*'  shift 129
+	'['  shift 134
+	.  error
+
+	type_data  goto 228
+	slice_count  goto 130
+
+142: shift/reduce conflict (shift 8(0), red'n 173(0)) on '\n'
+state 142
+	expr:  MAP '{'.opt_newlines expr_map opt_comma_newlines '}' 
+	opt_newlines: .    (173)
+
+	'\n'  shift 8
+	.  reduce 173 (src line 1088)
+
+	opt_newlines  goto 230
+	newlines  goto 126
+	newline  goto 7
+
+state 143
+	expr:  MAP '['.type_data ']' type_data '{' opt_newlines expr_map opt_comma_newlines '}' 
+
+	IDENT  shift 128
+	CHAN  shift 132
+	STRUCT  shift 133
+	MAP  shift 131
+	'*'  shift 129
+	'['  shift 134
+	.  error
+
+	type_data  goto 231
+	slice_count  goto 130
+
+state 144
+	expr:  '{' opt_newlines.expr_map opt_comma_newlines '}' 
+	expr_map: .    (119)
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  reduce 119 (src line 799)
+
+	expr  goto 233
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_map  goto 232
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 145
+	stmt_var:  VAR expr_idents.'=' exprs 
+	expr_idents:  expr_idents.',' opt_newlines IDENT 
+
+	'='  shift 234
+	','  shift 203
+	.  error
+
+
+state 146
+	expr_idents:  IDENT.    (96)
+
+	.  reduce 96 (src line 648)
+
+
+state 147
+	stmt_lets:  exprs '='.exprs 
+	exprs: .    (57)
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  reduce 57 (src line 455)
+
+	exprs  goto 235
+	expr  goto 71
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 148
+	stmt_lets:  exprs EQOPCHAN.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 236
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 149
+	exprs:  exprs ','.opt_newlines expr 
+	exprs:  exprs ','.opt_newlines expr_ident 
+	opt_newlines: .    (173)
+
+	'\n'  shift 8
+	.  reduce 173 (src line 1088)
+
+	opt_newlines  goto 237
+	newlines  goto 126
+	newline  goto 7
+
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on $end
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on VARARG
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on IN
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on EQEQ
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on NEQ
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on GE
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on LE
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on OROR
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on ANDAND
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on NILCOALESCE
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on PLUSEQ
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on MINUSEQ
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on MULEQ
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on DIVEQ
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on ANDEQ
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on OREQ
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on PLUSPLUS
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on MINUSMINUS
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on SHIFTLEFT
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on SHIFTRIGHT
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on CASE
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on DEFAULT
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on OPCHAN
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on EQOPCHAN
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on '='
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on ':'
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on '?'
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on '<'
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on '>'
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on '+'
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on '-'
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on '|'
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on '*'
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on '/'
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on '%'
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on '&'
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on '{'
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on '}'
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on '('
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on ')'
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on ','
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on ';'
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on '['
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on ']'
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on '.'
+ 150: reduce/reduce conflict  (red'ns 113 and 114) on '\n'
+state 150
+	expr_literals:  '-' NUMBER.    (113)
+	expr_literals:  NUMBER.    (114)
+
+	.  reduce 113 (src line 759)
+
+
+151: shift/reduce conflict (shift 84(0), red'n 134(13)) on '('
+151: shift/reduce conflict (shift 85(0), red'n 134(13)) on '['
+151: shift/reduce conflict (shift 87(0), red'n 134(13)) on '.'
+state 151
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_unary:  '-' expr.    (134)
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 134 (src line 869)
+
+
+152: shift/reduce conflict (shift 84(0), red'n 133(4)) on '('
+152: shift/reduce conflict (shift 85(0), red'n 133(4)) on '['
+152: shift/reduce conflict (shift 87(0), red'n 133(4)) on '.'
+state 152
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_chan:  OPCHAN expr.    (133)
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 133 (src line 864)
+
+
+153: shift/reduce conflict (shift 84(0), red'n 135(13)) on '('
+153: shift/reduce conflict (shift 85(0), red'n 135(13)) on '['
+153: shift/reduce conflict (shift 87(0), red'n 135(13)) on '.'
+state 153
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_unary:  '!' expr.    (135)
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 135 (src line 875)
+
+
+154: shift/reduce conflict (shift 84(0), red'n 136(13)) on '('
+154: shift/reduce conflict (shift 85(0), red'n 136(13)) on '['
+154: shift/reduce conflict (shift 87(0), red'n 136(13)) on '.'
+state 154
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_unary:  '^' expr.    (136)
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 136 (src line 880)
+
+
+155: shift/reduce conflict (shift 84(0), red'n 137(13)) on '('
+155: shift/reduce conflict (shift 85(0), red'n 137(13)) on '['
+155: shift/reduce conflict (shift 87(0), red'n 137(13)) on '.'
+state 155
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_unary:  '&' expr.    (137)
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 137 (src line 885)
+
+
+156: shift/reduce conflict (shift 84(0), red'n 138(13)) on '('
+156: shift/reduce conflict (shift 85(0), red'n 138(13)) on '['
+156: shift/reduce conflict (shift 87(0), red'n 138(13)) on '.'
+state 156
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_unary:  '*' expr.    (138)
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 138 (src line 890)
+
+
+state 157
+	stmts:  stmts term stmt.    (4)
+
+	.  reduce 4 (src line 126)
+
+
+158: shift/reduce conflict (shift 5(0), red'n 168(0)) on ';'
+158: shift/reduce conflict (shift 8(0), red'n 168(0)) on '\n'
+state 158
+	stmt:  MODULE IDENT '{'.compstmt '}' 
+	opt_term: .    (168)
+
+	';'  shift 5
+	'\n'  shift 8
+	.  reduce 168 (src line 1079)
+
+	compstmt  goto 238
+	stmts  goto 3
+	opt_term  goto 2
+	term  goto 4
+	newlines  goto 6
+	newline  goto 7
+
+state 159
+	stmt:  TRY '{' compstmt.'}' CATCH IDENT '{' compstmt '}' FINALLY '{' compstmt '}' 
+	stmt:  TRY '{' compstmt.'}' CATCH '{' compstmt '}' FINALLY '{' compstmt '}' 
+	stmt:  TRY '{' compstmt.'}' CATCH IDENT '{' compstmt '}' 
+	stmt:  TRY '{' compstmt.'}' CATCH '{' compstmt '}' 
+
+	'}'  shift 239
+	.  error
+
+
+state 160
+	stmt:  GO IDENT '('.exprs VARARG ')' 
+	stmt:  GO IDENT '('.exprs ')' 
+	expr:  IDENT '('.exprs VARARG ')' 
+	expr:  IDENT '('.exprs ')' 
+	exprs: .    (57)
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  reduce 57 (src line 455)
+
+	exprs  goto 240
+	expr  goto 71
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 161
+	stmt:  GO expr '('.exprs VARARG ')' 
+	stmt:  GO expr '('.exprs ')' 
+	expr:  expr '('.exprs VARARG ')' 
+	expr:  expr '('.exprs ')' 
+	exprs: .    (57)
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  reduce 57 (src line 455)
+
+	exprs  goto 241
+	expr  goto 71
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 162
+	stmt:  DELETE '(' expr.')' 
+	stmt:  DELETE '(' expr.',' expr ')' 
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	')'  shift 242
+	','  shift 243
+	'['  shift 85
+	'.'  shift 87
+	.  error
+
+
+state 163
+	stmt:  CLOSE '(' expr.')' 
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	')'  shift 244
+	'['  shift 85
+	'.'  shift 87
+	.  error
+
+
+state 164
+	stmt_if:  stmt_if ELSE IF.expr '{' compstmt '}' 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 245
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+165: shift/reduce conflict (shift 5(0), red'n 168(0)) on ';'
+165: shift/reduce conflict (shift 8(0), red'n 168(0)) on '\n'
+state 165
+	stmt_if:  stmt_if ELSE '{'.compstmt '}' 
+	opt_term: .    (168)
+
+	';'  shift 5
+	'\n'  shift 8
+	.  reduce 168 (src line 1079)
+
+	compstmt  goto 246
+	stmts  goto 3
+	opt_term  goto 2
+	term  goto 4
+	newlines  goto 6
+	newline  goto 7
+
+state 166
+	stmt_lets:  expr '=' expr.    (30)
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 30 (src line 265)
+
+
+state 167
+	stmt_lets:  expr EQOPCHAN expr.    (32)
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 32 (src line 294)
+
+
+state 168
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr '?' expr.':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	':'  shift 247
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  error
+
+
+169: shift/reduce conflict (shift 84(0), red'n 64(5)) on '('
+169: shift/reduce conflict (shift 85(0), red'n 64(5)) on '['
+169: shift/reduce conflict (shift 87(0), red'n 64(5)) on '.'
+state 169
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr NILCOALESCE expr.    (64)
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 64 (src line 493)
+
+
+state 170
+	exprs:  exprs.',' opt_newlines expr 
+	exprs:  exprs.',' opt_newlines expr_ident 
+	expr:  expr '(' exprs.VARARG ')' 
+	expr:  expr '(' exprs.')' 
+
+	VARARG  shift 248
+	')'  shift 249
+	','  shift 149
+	.  error
+
+
+state 171
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr '[' expr.']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr '[' expr.':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr '[' expr.':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_slice:  expr '[' expr.':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	':'  shift 251
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	']'  shift 250
+	'.'  shift 87
+	.  error
+
+
+state 172
+	expr_slice:  expr '[' ':'.expr ']' 
+	expr_slice:  expr '[' ':'.expr ':' expr ']' 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 252
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+173: shift/reduce conflict (shift 84(0), red'n 86(11)) on '('
+173: shift/reduce conflict (shift 85(0), red'n 86(11)) on '['
+173: shift/reduce conflict (shift 87(0), red'n 86(11)) on '.'
+state 173
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr:  expr IN expr.    (86)
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 86 (src line 608)
+
+
+state 174
+	expr_member:  expr '.' IDENT.    (111)
+
+	.  reduce 111 (src line 745)
+
+
+175: shift/reduce conflict (shift 84(0), red'n 132(4)) on '('
+175: shift/reduce conflict (shift 85(0), red'n 132(4)) on '['
+175: shift/reduce conflict (shift 87(0), red'n 132(4)) on '.'
+state 175
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_chan:  expr OPCHAN expr.    (132)
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 132 (src line 859)
+
+
+176: shift/reduce conflict (shift 84(0), red'n 145(2)) on '('
+176: shift/reduce conflict (shift 85(0), red'n 145(2)) on '['
+176: shift/reduce conflict (shift 87(0), red'n 145(2)) on '.'
+state 176
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr PLUSEQ expr.    (145)
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 145 (src line 935)
+
+
+177: shift/reduce conflict (shift 84(0), red'n 146(2)) on '('
+177: shift/reduce conflict (shift 85(0), red'n 146(2)) on '['
+177: shift/reduce conflict (shift 87(0), red'n 146(2)) on '.'
+state 177
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr MINUSEQ expr.    (146)
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 146 (src line 943)
+
+
+178: shift/reduce conflict (shift 84(0), red'n 147(2)) on '('
+178: shift/reduce conflict (shift 85(0), red'n 147(2)) on '['
+178: shift/reduce conflict (shift 87(0), red'n 147(2)) on '.'
+state 178
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr OREQ expr.    (147)
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 147 (src line 951)
+
+
+179: shift/reduce conflict (shift 84(0), red'n 148(2)) on '('
+179: shift/reduce conflict (shift 85(0), red'n 148(2)) on '['
+179: shift/reduce conflict (shift 87(0), red'n 148(2)) on '.'
+state 179
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr MULEQ expr.    (148)
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 148 (src line 959)
+
+
+180: shift/reduce conflict (shift 84(0), red'n 149(2)) on '('
+180: shift/reduce conflict (shift 85(0), red'n 149(2)) on '['
+180: shift/reduce conflict (shift 87(0), red'n 149(2)) on '.'
+state 180
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr DIVEQ expr.    (149)
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 149 (src line 967)
+
+
+181: shift/reduce conflict (shift 84(0), red'n 150(2)) on '('
+181: shift/reduce conflict (shift 85(0), red'n 150(2)) on '['
+181: shift/reduce conflict (shift 87(0), red'n 150(2)) on '.'
+state 181
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	expr_lets:  expr ANDEQ expr.    (150)
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 150 (src line 975)
+
+
+182: shift/reduce conflict (shift 84(0), red'n 151(10)) on '('
+182: shift/reduce conflict (shift 85(0), red'n 151(10)) on '['
+182: shift/reduce conflict (shift 87(0), red'n 151(10)) on '.'
+state 182
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr '*' expr.    (151)
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 151 (src line 985)
+
+
+183: shift/reduce conflict (shift 84(0), red'n 152(10)) on '('
+183: shift/reduce conflict (shift 85(0), red'n 152(10)) on '['
+183: shift/reduce conflict (shift 87(0), red'n 152(10)) on '.'
+state 183
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr '/' expr.    (152)
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 152 (src line 991)
+
+
+184: shift/reduce conflict (shift 84(0), red'n 153(10)) on '('
+184: shift/reduce conflict (shift 85(0), red'n 153(10)) on '['
+184: shift/reduce conflict (shift 87(0), red'n 153(10)) on '.'
+state 184
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr '%' expr.    (153)
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 153 (src line 996)
+
+
+185: shift/reduce conflict (shift 84(0), red'n 154(10)) on '('
+185: shift/reduce conflict (shift 85(0), red'n 154(10)) on '['
+185: shift/reduce conflict (shift 87(0), red'n 154(10)) on '.'
+state 185
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr SHIFTLEFT expr.    (154)
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 154 (src line 1001)
+
+
+186: shift/reduce conflict (shift 84(0), red'n 155(10)) on '('
+186: shift/reduce conflict (shift 85(0), red'n 155(10)) on '['
+186: shift/reduce conflict (shift 87(0), red'n 155(10)) on '.'
+state 186
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr SHIFTRIGHT expr.    (155)
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 155 (src line 1006)
+
+
+187: shift/reduce conflict (shift 84(0), red'n 156(10)) on '('
+187: shift/reduce conflict (shift 85(0), red'n 156(10)) on '['
+187: shift/reduce conflict (shift 87(0), red'n 156(10)) on '.'
+state 187
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_multiply:  expr '&' expr.    (156)
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 156 (src line 1011)
+
+
+188: shift/reduce conflict (shift 84(0), red'n 157(9)) on '('
+188: shift/reduce conflict (shift 85(0), red'n 157(9)) on '['
+188: shift/reduce conflict (shift 87(0), red'n 157(9)) on '.'
+state 188
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr '+' expr.    (157)
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 157 (src line 1017)
+
+
+189: shift/reduce conflict (shift 84(0), red'n 158(9)) on '('
+189: shift/reduce conflict (shift 85(0), red'n 158(9)) on '['
+189: shift/reduce conflict (shift 87(0), red'n 158(9)) on '.'
+state 189
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr '-' expr.    (158)
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 158 (src line 1023)
+
+
+190: shift/reduce conflict (shift 84(0), red'n 159(9)) on '('
+190: shift/reduce conflict (shift 85(0), red'n 159(9)) on '['
+190: shift/reduce conflict (shift 87(0), red'n 159(9)) on '.'
+state 190
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_add:  expr '|' expr.    (159)
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 159 (src line 1028)
+
+
+191: shift/reduce conflict (shift 84(0), red'n 160(8)) on '('
+191: shift/reduce conflict (shift 85(0), red'n 160(8)) on '['
+191: shift/reduce conflict (shift 87(0), red'n 160(8)) on '.'
+state 191
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr EQEQ expr.    (160)
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 160 (src line 1034)
+
+
+192: shift/reduce conflict (shift 84(0), red'n 161(8)) on '('
+192: shift/reduce conflict (shift 85(0), red'n 161(8)) on '['
+192: shift/reduce conflict (shift 87(0), red'n 161(8)) on '.'
+state 192
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr NEQ expr.    (161)
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 161 (src line 1040)
+
+
+193: shift/reduce conflict (shift 84(0), red'n 162(8)) on '('
+193: shift/reduce conflict (shift 85(0), red'n 162(8)) on '['
+193: shift/reduce conflict (shift 87(0), red'n 162(8)) on '.'
+state 193
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr '<' expr.    (162)
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 162 (src line 1045)
+
+
+194: shift/reduce conflict (shift 84(0), red'n 163(8)) on '('
+194: shift/reduce conflict (shift 85(0), red'n 163(8)) on '['
+194: shift/reduce conflict (shift 87(0), red'n 163(8)) on '.'
+state 194
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr LE expr.    (163)
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 163 (src line 1050)
+
+
+195: shift/reduce conflict (shift 84(0), red'n 164(8)) on '('
+195: shift/reduce conflict (shift 85(0), red'n 164(8)) on '['
+195: shift/reduce conflict (shift 87(0), red'n 164(8)) on '.'
+state 195
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr '>' expr.    (164)
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 164 (src line 1055)
+
+
+196: shift/reduce conflict (shift 84(0), red'n 165(8)) on '('
+196: shift/reduce conflict (shift 85(0), red'n 165(8)) on '['
+196: shift/reduce conflict (shift 87(0), red'n 165(8)) on '.'
+state 196
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_comparison:  expr GE expr.    (165)
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 165 (src line 1060)
+
+
+197: shift/reduce conflict (shift 84(0), red'n 166(7)) on '('
+197: shift/reduce conflict (shift 85(0), red'n 166(7)) on '['
+197: shift/reduce conflict (shift 87(0), red'n 166(7)) on '.'
+state 197
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr ANDAND expr.    (166)
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 166 (src line 1066)
+
+
+198: shift/reduce conflict (shift 84(0), red'n 167(6)) on '('
+198: shift/reduce conflict (shift 85(0), red'n 167(6)) on '['
+198: shift/reduce conflict (shift 87(0), red'n 167(6)) on '.'
+state 198
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+	op_binary:  expr OROR expr.    (167)
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	ANDAND  shift 112
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 167 (src line 1072)
+
+
+199: shift/reduce conflict (shift 5(0), red'n 168(0)) on ';'
+199: shift/reduce conflict (shift 8(0), red'n 168(0)) on '\n'
+state 199
+	stmt_if:  IF expr '{'.compstmt '}' 
+	opt_term: .    (168)
+
+	';'  shift 5
+	'\n'  shift 8
+	.  reduce 168 (src line 1079)
+
+	compstmt  goto 253
+	stmts  goto 3
+	opt_term  goto 2
+	term  goto 4
+	newlines  goto 6
+	newline  goto 7
+
+state 200
+	stmt_for:  FOR '{' compstmt.'}' 
+
+	'}'  shift 254
+	.  error
+
+
+201: shift/reduce conflict (shift 8(0), red'n 171(0)) on '\n'
+ 201: reduce/reduce conflict  (red'ns 171 and 174) on IDENT
+ 201: reduce/reduce conflict  (red'ns 171 and 174) on NUMBER
+ 201: reduce/reduce conflict  (red'ns 171 and 174) on STRING
+ 201: reduce/reduce conflict  (red'ns 171 and 174) on FUNC
+ 201: reduce/reduce conflict  (red'ns 171 and 174) on NEW
+ 201: reduce/reduce conflict  (red'ns 171 and 174) on TRUE
+ 201: reduce/reduce conflict  (red'ns 171 and 174) on FALSE
+ 201: reduce/reduce conflict  (red'ns 171 and 174) on NIL
+ 201: reduce/reduce conflict  (red'ns 171 and 174) on MAKE
+ 201: reduce/reduce conflict  (red'ns 171 and 174) on OPCHAN
+ 201: reduce/reduce conflict  (red'ns 171 and 174) on LEN
+ 201: reduce/reduce conflict  (red'ns 171 and 174) on MAP
+ 201: reduce/reduce conflict  (red'ns 171 and 174) on IMPORT
+ 201: reduce/reduce conflict  (red'ns 171 and 174) on '-'
+ 201: reduce/reduce conflict  (red'ns 171 and 174) on '^'
+ 201: reduce/reduce conflict  (red'ns 171 and 174) on '*'
+ 201: reduce/reduce conflict  (red'ns 171 and 174) on '&'
+ 201: reduce/reduce conflict  (red'ns 171 and 174) on '{'
+ 201: reduce/reduce conflict  (red'ns 171 and 174) on '}'
+ 201: reduce/reduce conflict  (red'ns 171 and 174) on '('
+ 201: reduce/reduce conflict  (red'ns 171 and 174) on ','
+ 201: reduce/reduce conflict  (red'ns 171 and 174) on '['
+ 201: reduce/reduce conflict  (red'ns 171 and 174) on '!'
+201: shift/reduce conflict (shift 8(0), red'n 174(0)) on '\n'
+state 201
+	term:  newlines.    (171)
+	opt_newlines:  newlines.    (174)
+	newlines:  newlines.newline 
+
+	'\n'  shift 8
+	.  reduce 171 (src line 1085)
+
+	newline  goto 69
+
+state 202
+	stmt_for:  FOR expr_idents IN.expr '{' compstmt '}' 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 255
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 203
+	expr_idents:  expr_idents ','.opt_newlines IDENT 
+	opt_newlines: .    (173)
+
+	'\n'  shift 8
+	.  reduce 173 (src line 1088)
+
+	opt_newlines  goto 256
+	newlines  goto 126
+	newline  goto 7
+
+204: shift/reduce conflict (shift 5(0), red'n 168(0)) on ';'
+204: shift/reduce conflict (shift 8(0), red'n 168(0)) on '\n'
+state 204
+	stmt_for:  FOR expr '{'.compstmt '}' 
+	opt_term: .    (168)
+
+	';'  shift 5
+	'\n'  shift 8
+	.  reduce 168 (src line 1079)
+
+	compstmt  goto 257
+	stmts  goto 3
+	opt_term  goto 2
+	term  goto 4
+	newlines  goto 6
+	newline  goto 7
+
+state 205
+	stmt_for:  FOR ';' ';'.'{' compstmt '}' 
+	stmt_for:  FOR ';' ';'.expr '{' compstmt '}' 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 258
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 259
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 206
+	stmt_for:  FOR ';' expr.';' '{' compstmt '}' 
+	stmt_for:  FOR ';' expr.';' expr '{' compstmt '}' 
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	';'  shift 260
+	'['  shift 85
+	'.'  shift 87
+	.  error
+
+
+state 207
+	stmt_for:  FOR stmt_var_or_lets ';'.';' '{' compstmt '}' 
+	stmt_for:  FOR stmt_var_or_lets ';'.';' expr '{' compstmt '}' 
+	stmt_for:  FOR stmt_var_or_lets ';'.expr ';' '{' compstmt '}' 
+	stmt_for:  FOR stmt_var_or_lets ';'.expr ';' expr '{' compstmt '}' 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	';'  shift 261
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 262
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+208: shift/reduce conflict (shift 8(0), red'n 173(0)) on '\n'
+state 208
+	stmt_switch:  SWITCH expr '{'.opt_newlines stmt_switch_cases opt_newlines '}' 
+	opt_newlines: .    (173)
+
+	'\n'  shift 8
+	.  reduce 173 (src line 1088)
+
+	opt_newlines  goto 263
+	newlines  goto 126
+	newline  goto 7
+
+state 209
+	expr:  FUNC '(' expr_idents.')' '{' compstmt '}' 
+	expr:  FUNC '(' expr_idents.VARARG ')' '{' compstmt '}' 
+	expr_idents:  expr_idents.',' opt_newlines IDENT 
+
+	VARARG  shift 265
+	')'  shift 264
+	','  shift 203
+	.  error
+
+
+state 210
+	expr:  FUNC IDENT '('.expr_idents ')' '{' compstmt '}' 
+	expr:  FUNC IDENT '('.expr_idents VARARG ')' '{' compstmt '}' 
+	expr_idents: .    (95)
+
+	IDENT  shift 146
+	.  reduce 95 (src line 644)
+
+	expr_idents  goto 266
+
+state 211
+	slice_count:  '[' ']' slice_count.    (108)
+
+	.  reduce 108 (src line 730)
+
+
+state 212
+	exprs:  exprs.',' opt_newlines expr 
+	exprs:  exprs.',' opt_newlines expr_ident 
+	expr:  '[' opt_newlines exprs.opt_comma_newlines ']' 
+	opt_comma_newlines: .    (178)
+
+	','  shift 267
+	'\n'  shift 8
+	.  reduce 178 (src line 1098)
+
+	opt_comma_newlines  goto 268
+	newlines  goto 269
+	newline  goto 7
+
+213: shift/reduce conflict (shift 8(0), red'n 173(0)) on '\n'
+state 213
+	expr:  slice_count type_data '{'.opt_newlines exprs opt_comma_newlines '}' 
+	opt_newlines: .    (173)
+
+	'\n'  shift 8
+	.  reduce 173 (src line 1088)
+
+	opt_newlines  goto 270
+	newlines  goto 126
+	newline  goto 7
+
+state 214
+	type_data:  type_data '.'.IDENT 
+
+	IDENT  shift 271
+	.  error
+
+
+215: shift/reduce conflict (shift 214(0), red'n 100(10)) on '.'
+state 215
+	type_data:  type_data.'.' IDENT 
+	type_data:  '*' type_data.    (100)
+
+	'.'  shift 214
+	.  reduce 100 (src line 674)
+
+
+216: shift/reduce conflict (shift 214(0), red'n 101(0)) on '.'
+state 216
+	type_data:  type_data.'.' IDENT 
+	type_data:  slice_count type_data.    (101)
+
+	'.'  shift 214
+	.  reduce 101 (src line 683)
+
+
+state 217
+	type_data:  MAP '['.type_data ']' type_data 
+
+	IDENT  shift 128
+	CHAN  shift 132
+	STRUCT  shift 133
+	MAP  shift 131
+	'*'  shift 129
+	'['  shift 134
+	.  error
+
+	type_data  goto 272
+	slice_count  goto 130
+
+218: shift/reduce conflict (shift 214(0), red'n 103(0)) on '.'
+state 218
+	type_data:  type_data.'.' IDENT 
+	type_data:  CHAN type_data.    (103)
+
+	'.'  shift 214
+	.  reduce 103 (src line 697)
+
+
+state 219
+	type_data:  STRUCT '{'.opt_newlines type_data_struct opt_newlines '}' 
+	opt_newlines: .    (173)
+
+	'\n'  shift 8
+	.  reduce 173 (src line 1088)
+
+	opt_newlines  goto 273
+	newlines  goto 126
+	newline  goto 7
+
+220: shift/reduce conflict (shift 134(0), red'n 107(0)) on '['
+state 220
+	slice_count:  '[' ']'.    (107)
+	slice_count:  '[' ']'.slice_count 
+
+	'['  shift 134
+	.  reduce 107 (src line 725)
+
+	slice_count  goto 211
+
+state 221
+	expr:  '(' expr ')'.    (72)
+
+	.  reduce 72 (src line 533)
+
+
+state 222
+	exprs:  exprs.',' opt_newlines expr 
+	exprs:  exprs.',' opt_newlines expr_ident 
+	expr:  IDENT '(' exprs.VARARG ')' 
+	expr:  IDENT '(' exprs.')' 
+
+	VARARG  shift 274
+	')'  shift 275
+	','  shift 149
+	.  error
+
+
+state 223
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr_ident '[' expr.']' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr_ident '[' expr.':' expr ']' 
+	expr_slice:  expr_ident '[' expr.':' ']' 
+	expr_slice:  expr_ident '[' expr.':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	':'  shift 277
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	']'  shift 276
+	'.'  shift 87
+	.  error
+
+
+state 224
+	expr_slice:  expr_ident '[' ':'.expr ']' 
+	expr_slice:  expr_ident '[' ':'.expr ':' expr ']' 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 278
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 225
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  LEN '(' expr.')' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	')'  shift 279
+	'['  shift 85
+	'.'  shift 87
+	.  error
+
+
+state 226
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  IMPORT '(' expr.')' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	')'  shift 280
+	'['  shift 85
+	'.'  shift 87
+	.  error
+
+
+state 227
+	expr:  NEW '(' type_data.')' 
+	type_data:  type_data.'.' IDENT 
+
+	')'  shift 281
+	'.'  shift 214
+	.  error
+
+
+state 228
+	expr:  MAKE '(' type_data.')' 
+	expr:  MAKE '(' type_data.',' expr ')' 
+	expr:  MAKE '(' type_data.',' expr ',' expr ')' 
+	type_data:  type_data.'.' IDENT 
+
+	')'  shift 282
+	','  shift 283
+	'.'  shift 214
+	.  error
+
+
+state 229
+	expr:  MAKE '(' TYPE.IDENT ',' expr ')' 
+
+	IDENT  shift 284
+	.  error
+
+
+state 230
+	expr:  MAP '{' opt_newlines.expr_map opt_comma_newlines '}' 
+	expr_map: .    (119)
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  reduce 119 (src line 799)
+
+	expr  goto 233
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_map  goto 285
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 231
+	expr:  MAP '[' type_data.']' type_data '{' opt_newlines expr_map opt_comma_newlines '}' 
+	type_data:  type_data.'.' IDENT 
+
+	']'  shift 286
+	'.'  shift 214
+	.  error
+
+
+state 232
+	expr:  '{' opt_newlines expr_map.opt_comma_newlines '}' 
+	expr_map:  expr_map.',' opt_newlines expr ':' expr 
+	opt_comma_newlines: .    (178)
+
+	','  shift 288
+	'\n'  shift 8
+	.  reduce 178 (src line 1098)
+
+	opt_comma_newlines  goto 287
+	newlines  goto 269
+	newline  goto 7
+
+state 233
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_map:  expr.':' expr 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	':'  shift 289
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  error
+
+
+state 234
+	stmt_var:  VAR expr_idents '='.exprs 
+	exprs: .    (57)
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  reduce 57 (src line 455)
+
+	exprs  goto 290
+	expr  goto 71
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 235
+	stmt_lets:  exprs '=' exprs.    (31)
+	exprs:  exprs.',' opt_newlines expr 
+	exprs:  exprs.',' opt_newlines expr_ident 
+
+	','  shift 149
+	.  reduce 31 (src line 271)
+
+
+state 236
+	stmt_lets:  exprs EQOPCHAN expr.    (33)
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 33 (src line 299)
+
+
+state 237
+	exprs:  exprs ',' opt_newlines.expr 
+	exprs:  exprs ',' opt_newlines.expr_ident 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 291
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 292
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 238
+	stmt:  MODULE IDENT '{' compstmt.'}' 
+
+	'}'  shift 293
+	.  error
+
+
+state 239
+	stmt:  TRY '{' compstmt '}'.CATCH IDENT '{' compstmt '}' FINALLY '{' compstmt '}' 
+	stmt:  TRY '{' compstmt '}'.CATCH '{' compstmt '}' FINALLY '{' compstmt '}' 
+	stmt:  TRY '{' compstmt '}'.CATCH IDENT '{' compstmt '}' 
+	stmt:  TRY '{' compstmt '}'.CATCH '{' compstmt '}' 
+
+	CATCH  shift 294
+	.  error
+
+
+state 240
+	stmt:  GO IDENT '(' exprs.VARARG ')' 
+	stmt:  GO IDENT '(' exprs.')' 
+	exprs:  exprs.',' opt_newlines expr 
+	exprs:  exprs.',' opt_newlines expr_ident 
+	expr:  IDENT '(' exprs.VARARG ')' 
+	expr:  IDENT '(' exprs.')' 
+
+	VARARG  shift 295
+	')'  shift 296
+	','  shift 149
+	.  error
+
+
+state 241
+	stmt:  GO expr '(' exprs.VARARG ')' 
+	stmt:  GO expr '(' exprs.')' 
+	exprs:  exprs.',' opt_newlines expr 
+	exprs:  exprs.',' opt_newlines expr_ident 
+	expr:  expr '(' exprs.VARARG ')' 
+	expr:  expr '(' exprs.')' 
+
+	VARARG  shift 297
+	')'  shift 298
+	','  shift 149
+	.  error
+
+
+state 242
+	stmt:  DELETE '(' expr ')'.    (20)
+
+	.  reduce 20 (src line 215)
+
+
+state 243
+	stmt:  DELETE '(' expr ','.expr ')' 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 299
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 244
+	stmt:  CLOSE '(' expr ')'.    (22)
+
+	.  reduce 22 (src line 225)
+
+
+state 245
+	stmt_if:  stmt_if ELSE IF expr.'{' compstmt '}' 
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'{'  shift 300
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  error
+
+
+state 246
+	stmt_if:  stmt_if ELSE '{' compstmt.'}' 
+
+	'}'  shift 301
+	.  error
+
+
+state 247
+	expr:  expr '?' expr ':'.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 302
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 248
+	expr:  expr '(' exprs VARARG.')' 
+
+	')'  shift 303
+	.  error
+
+
+state 249
+	expr:  expr '(' exprs ')'.    (76)
+
+	.  reduce 76 (src line 553)
+
+
+state 250
+	expr:  expr '[' expr ']'.    (78)
+
+	.  reduce 78 (src line 563)
+
+
+state 251
+	expr_slice:  expr '[' expr ':'.expr ']' 
+	expr_slice:  expr '[' expr ':'.']' 
+	expr_slice:  expr '[' expr ':'.expr ':' expr ']' 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	']'  shift 305
+	'!'  shift 58
+	.  error
+
+	expr  goto 304
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 252
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr '[' ':' expr.']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr '[' ':' expr.':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	':'  shift 307
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	']'  shift 306
+	'.'  shift 87
+	.  error
+
+
+state 253
+	stmt_if:  IF expr '{' compstmt.'}' 
+
+	'}'  shift 308
+	.  error
+
+
+state 254
+	stmt_for:  FOR '{' compstmt '}'.    (37)
+
+	.  reduce 37 (src line 336)
+
+
+state 255
+	stmt_for:  FOR expr_idents IN expr.'{' compstmt '}' 
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'{'  shift 309
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  error
+
+
+state 256
+	expr_idents:  expr_idents ',' opt_newlines.IDENT 
+
+	IDENT  shift 310
+	.  error
+
+
+state 257
+	stmt_for:  FOR expr '{' compstmt.'}' 
+
+	'}'  shift 311
+	.  error
+
+
+258: shift/reduce conflict (shift 8(0), red'n 173(0)) on '\n'
+ 258: reduce/reduce conflict  (red'ns 173 and 168) on IDENT
+ 258: reduce/reduce conflict  (red'ns 173 and 168) on NUMBER
+ 258: reduce/reduce conflict  (red'ns 173 and 168) on STRING
+ 258: reduce/reduce conflict  (red'ns 173 and 168) on FUNC
+ 258: reduce/reduce conflict  (red'ns 173 and 168) on NEW
+ 258: reduce/reduce conflict  (red'ns 173 and 168) on TRUE
+ 258: reduce/reduce conflict  (red'ns 173 and 168) on FALSE
+ 258: reduce/reduce conflict  (red'ns 173 and 168) on NIL
+ 258: reduce/reduce conflict  (red'ns 173 and 168) on MAKE
+ 258: reduce/reduce conflict  (red'ns 173 and 168) on OPCHAN
+ 258: reduce/reduce conflict  (red'ns 173 and 168) on LEN
+ 258: reduce/reduce conflict  (red'ns 173 and 168) on MAP
+ 258: reduce/reduce conflict  (red'ns 173 and 168) on IMPORT
+ 258: reduce/reduce conflict  (red'ns 173 and 168) on '-'
+ 258: reduce/reduce conflict  (red'ns 173 and 168) on '^'
+ 258: reduce/reduce conflict  (red'ns 173 and 168) on '*'
+ 258: reduce/reduce conflict  (red'ns 173 and 168) on '&'
+ 258: reduce/reduce conflict  (red'ns 173 and 168) on '{'
+ 258: reduce/reduce conflict  (red'ns 173 and 168) on '}'
+ 258: reduce/reduce conflict  (red'ns 173 and 168) on '('
+ 258: reduce/reduce conflict  (red'ns 173 and 168) on ','
+258: shift/reduce conflict (shift 5(0), red'n 168(0)) on ';'
+ 258: reduce/reduce conflict  (red'ns 173 and 168) on '['
+ 258: reduce/reduce conflict  (red'ns 173 and 168) on '!'
+258: shift/reduce conflict (shift 8(0), red'n 168(0)) on '\n'
+state 258
+	stmt_for:  FOR ';' ';' '{'.compstmt '}' 
+	expr:  '{'.opt_newlines expr_map opt_comma_newlines '}' 
+	opt_newlines: .    (173)
+	opt_term: .    (168)
+
+	';'  shift 5
+	'\n'  shift 8
+	.  reduce 168 (src line 1079)
+
+	compstmt  goto 312
+	stmts  goto 3
+	opt_term  goto 2
+	term  goto 4
+	opt_newlines  goto 144
+	newlines  goto 201
+	newline  goto 7
+
+state 259
+	stmt_for:  FOR ';' ';' expr.'{' compstmt '}' 
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'{'  shift 313
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  error
+
+
+state 260
+	stmt_for:  FOR ';' expr ';'.'{' compstmt '}' 
+	stmt_for:  FOR ';' expr ';'.expr '{' compstmt '}' 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 314
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 315
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 261
+	stmt_for:  FOR stmt_var_or_lets ';' ';'.'{' compstmt '}' 
+	stmt_for:  FOR stmt_var_or_lets ';' ';'.expr '{' compstmt '}' 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 316
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 317
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 262
+	stmt_for:  FOR stmt_var_or_lets ';' expr.';' '{' compstmt '}' 
+	stmt_for:  FOR stmt_var_or_lets ';' expr.';' expr '{' compstmt '}' 
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	';'  shift 318
+	'['  shift 85
+	'.'  shift 87
+	.  error
+
+
+263: shift/reduce conflict (shift 323(0), red'n 49(0)) on CASE
+263: shift/reduce conflict (shift 322(0), red'n 49(0)) on DEFAULT
+state 263
+	stmt_switch:  SWITCH expr '{' opt_newlines.stmt_switch_cases opt_newlines '}' 
+	stmt_switch_cases: .    (49)
+
+	CASE  shift 323
+	DEFAULT  shift 322
+	.  reduce 49 (src line 408)
+
+	stmt_switch_cases  goto 319
+	stmt_switch_case  goto 321
+	stmt_switch_default  goto 320
+
+state 264
+	expr:  FUNC '(' expr_idents ')'.'{' compstmt '}' 
+
+	'{'  shift 324
+	.  error
+
+
+state 265
+	expr:  FUNC '(' expr_idents VARARG.')' '{' compstmt '}' 
+
+	')'  shift 325
+	.  error
+
+
+state 266
+	expr:  FUNC IDENT '(' expr_idents.')' '{' compstmt '}' 
+	expr:  FUNC IDENT '(' expr_idents.VARARG ')' '{' compstmt '}' 
+	expr_idents:  expr_idents.',' opt_newlines IDENT 
+
+	VARARG  shift 327
+	')'  shift 326
+	','  shift 203
+	.  error
+
+
+state 267
+	exprs:  exprs ','.opt_newlines expr 
+	exprs:  exprs ','.opt_newlines expr_ident 
+	opt_comma_newlines:  ','.newlines 
+	opt_comma_newlines:  ','.    (181)
+	opt_newlines: .    (173)
+
+	'}'  reduce 181 (src line 1102)
+	']'  reduce 181 (src line 1102)
+	'\n'  shift 8
+	.  reduce 173 (src line 1088)
+
+	opt_newlines  goto 237
+	newlines  goto 328
+	newline  goto 7
+
+state 268
+	expr:  '[' opt_newlines exprs opt_comma_newlines.']' 
+
+	']'  shift 329
+	.  error
+
+
+state 269
+	newlines:  newlines.newline 
+	opt_comma_newlines:  newlines.    (180)
+
+	'\n'  shift 8
+	.  reduce 180 (src line 1101)
+
+	newline  goto 69
+
+state 270
+	expr:  slice_count type_data '{' opt_newlines.exprs opt_comma_newlines '}' 
+	exprs: .    (57)
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  reduce 57 (src line 455)
+
+	exprs  goto 330
+	expr  goto 71
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 271
+	type_data:  type_data '.' IDENT.    (99)
+
+	.  reduce 99 (src line 665)
+
+
+state 272
+	type_data:  type_data.'.' IDENT 
+	type_data:  MAP '[' type_data.']' type_data 
+
+	']'  shift 331
+	'.'  shift 214
+	.  error
+
+
+state 273
+	type_data:  STRUCT '{' opt_newlines.type_data_struct opt_newlines '}' 
+
+	IDENT  shift 333
+	.  error
+
+	type_data_struct  goto 332
+
+state 274
+	expr:  IDENT '(' exprs VARARG.')' 
+
+	')'  shift 334
+	.  error
+
+
+state 275
+	expr:  IDENT '(' exprs ')'.    (74)
+
+	.  reduce 74 (src line 543)
+
+
+state 276
+	expr:  expr_ident '[' expr ']'.    (77)
+
+	.  reduce 77 (src line 558)
+
+
+state 277
+	expr_slice:  expr_ident '[' expr ':'.expr ']' 
+	expr_slice:  expr_ident '[' expr ':'.']' 
+	expr_slice:  expr_ident '[' expr ':'.expr ':' expr ']' 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	']'  shift 336
+	'!'  shift 58
+	.  error
+
+	expr  goto 335
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 278
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr_ident '[' ':' expr.']' 
+	expr_slice:  expr_ident '[' ':' expr.':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	':'  shift 338
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	']'  shift 337
+	'.'  shift 87
+	.  error
+
+
+state 279
+	expr:  LEN '(' expr ')'.    (79)
+
+	.  reduce 79 (src line 568)
+
+
+state 280
+	expr:  IMPORT '(' expr ')'.    (80)
+
+	.  reduce 80 (src line 573)
+
+
+state 281
+	expr:  NEW '(' type_data ')'.    (81)
+
+	.  reduce 81 (src line 578)
+
+
+state 282
+	expr:  MAKE '(' type_data ')'.    (82)
+
+	.  reduce 82 (src line 588)
+
+
+state 283
+	expr:  MAKE '(' type_data ','.expr ')' 
+	expr:  MAKE '(' type_data ','.expr ',' expr ')' 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 339
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 284
+	expr:  MAKE '(' TYPE IDENT.',' expr ')' 
+
+	','  shift 340
+	.  error
+
+
+state 285
+	expr:  MAP '{' opt_newlines expr_map.opt_comma_newlines '}' 
+	expr_map:  expr_map.',' opt_newlines expr ':' expr 
+	opt_comma_newlines: .    (178)
+
+	','  shift 288
+	'\n'  shift 8
+	.  reduce 178 (src line 1098)
+
+	opt_comma_newlines  goto 341
+	newlines  goto 269
+	newline  goto 7
+
+state 286
+	expr:  MAP '[' type_data ']'.type_data '{' opt_newlines expr_map opt_comma_newlines '}' 
+
+	IDENT  shift 128
+	CHAN  shift 132
+	STRUCT  shift 133
+	MAP  shift 131
+	'*'  shift 129
+	'['  shift 134
+	.  error
+
+	type_data  goto 342
+	slice_count  goto 130
+
+state 287
+	expr:  '{' opt_newlines expr_map opt_comma_newlines.'}' 
+
+	'}'  shift 343
+	.  error
+
+
+state 288
+	expr_map:  expr_map ','.opt_newlines expr ':' expr 
+	opt_comma_newlines:  ','.newlines 
+	opt_comma_newlines:  ','.    (181)
+	opt_newlines: .    (173)
+
+	'}'  reduce 181 (src line 1102)
+	'\n'  shift 8
+	.  reduce 173 (src line 1088)
+
+	opt_newlines  goto 344
+	newlines  goto 328
+	newline  goto 7
+
+state 289
+	expr_map:  expr ':'.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 345
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 290
+	stmt_var:  VAR expr_idents '=' exprs.    (29)
+	exprs:  exprs.',' opt_newlines expr 
+	exprs:  exprs.',' opt_newlines expr_ident 
+
+	','  shift 149
+	.  reduce 29 (src line 258)
+
+
+state 291
+	exprs:  exprs ',' opt_newlines expr.    (59)
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 59 (src line 464)
+
+
+ 292: reduce/reduce conflict  (red'ns 60 and 110) on $end
+ 292: reduce/reduce conflict  (red'ns 60 and 110) on VARARG
+ 292: reduce/reduce conflict  (red'ns 60 and 110) on CASE
+ 292: reduce/reduce conflict  (red'ns 60 and 110) on DEFAULT
+ 292: reduce/reduce conflict  (red'ns 60 and 110) on EQOPCHAN
+ 292: reduce/reduce conflict  (red'ns 60 and 110) on '='
+ 292: reduce/reduce conflict  (red'ns 60 and 110) on ':'
+ 292: reduce/reduce conflict  (red'ns 60 and 110) on '}'
+ 292: reduce/reduce conflict  (red'ns 60 and 110) on ')'
+ 292: reduce/reduce conflict  (red'ns 60 and 110) on ','
+ 292: reduce/reduce conflict  (red'ns 60 and 110) on ';'
+292: shift/reduce conflict (shift 137(0), red'n 110(0)) on '['
+ 292: reduce/reduce conflict  (red'ns 60 and 110) on ']'
+ 292: reduce/reduce conflict  (red'ns 60 and 110) on '\n'
+state 292
+	exprs:  exprs ',' opt_newlines expr_ident.    (60)
+	expr:  expr_ident.'[' expr ']' 
+	expr_member_or_ident:  expr_ident.    (110)
+	expr_slice:  expr_ident.'[' expr ':' expr ']' 
+	expr_slice:  expr_ident.'[' expr ':' ']' 
+	expr_slice:  expr_ident.'[' ':' expr ']' 
+	expr_slice:  expr_ident.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr_ident.'[' expr ':' expr ':' expr ']' 
+
+	$end  reduce 60 (src line 471)
+	VARARG  reduce 60 (src line 471)
+	CASE  reduce 60 (src line 471)
+	DEFAULT  reduce 60 (src line 471)
+	EQOPCHAN  reduce 60 (src line 471)
+	'='  reduce 60 (src line 471)
+	':'  reduce 60 (src line 471)
+	'}'  reduce 60 (src line 471)
+	')'  reduce 60 (src line 471)
+	','  reduce 60 (src line 471)
+	';'  reduce 60 (src line 471)
+	'['  shift 137
+	']'  reduce 60 (src line 471)
+	'\n'  reduce 60 (src line 471)
+	.  reduce 110 (src line 740)
+
+
+state 293
+	stmt:  MODULE IDENT '{' compstmt '}'.    (11)
+
+	.  reduce 11 (src line 170)
+
+
+state 294
+	stmt:  TRY '{' compstmt '}' CATCH.IDENT '{' compstmt '}' FINALLY '{' compstmt '}' 
+	stmt:  TRY '{' compstmt '}' CATCH.'{' compstmt '}' FINALLY '{' compstmt '}' 
+	stmt:  TRY '{' compstmt '}' CATCH.IDENT '{' compstmt '}' 
+	stmt:  TRY '{' compstmt '}' CATCH.'{' compstmt '}' 
+
+	IDENT  shift 346
+	'{'  shift 347
+	.  error
+
+
+state 295
+	stmt:  GO IDENT '(' exprs VARARG.')' 
+	expr:  IDENT '(' exprs VARARG.')' 
+
+	')'  shift 348
+	.  error
+
+
+state 296
+	stmt:  GO IDENT '(' exprs ')'.    (17)
+	expr:  IDENT '(' exprs ')'.    (74)
+
+	$end  reduce 17 (src line 200)
+	CASE  reduce 17 (src line 200)
+	DEFAULT  reduce 17 (src line 200)
+	'}'  reduce 17 (src line 200)
+	';'  reduce 17 (src line 200)
+	'\n'  reduce 17 (src line 200)
+	.  reduce 74 (src line 543)
+
+
+state 297
+	stmt:  GO expr '(' exprs VARARG.')' 
+	expr:  expr '(' exprs VARARG.')' 
+
+	')'  shift 349
+	.  error
+
+
+state 298
+	stmt:  GO expr '(' exprs ')'.    (19)
+	expr:  expr '(' exprs ')'.    (76)
+
+	$end  reduce 19 (src line 210)
+	CASE  reduce 19 (src line 210)
+	DEFAULT  reduce 19 (src line 210)
+	'}'  reduce 19 (src line 210)
+	';'  reduce 19 (src line 210)
+	'\n'  reduce 19 (src line 210)
+	.  reduce 76 (src line 553)
+
+
+state 299
+	stmt:  DELETE '(' expr ',' expr.')' 
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	')'  shift 350
+	'['  shift 85
+	'.'  shift 87
+	.  error
+
+
+300: shift/reduce conflict (shift 5(0), red'n 168(0)) on ';'
+300: shift/reduce conflict (shift 8(0), red'n 168(0)) on '\n'
+state 300
+	stmt_if:  stmt_if ELSE IF expr '{'.compstmt '}' 
+	opt_term: .    (168)
+
+	';'  shift 5
+	'\n'  shift 8
+	.  reduce 168 (src line 1079)
+
+	compstmt  goto 351
+	stmts  goto 3
+	opt_term  goto 2
+	term  goto 4
+	newlines  goto 6
+	newline  goto 7
+
+state 301
+	stmt_if:  stmt_if ELSE '{' compstmt '}'.    (36)
+
+	.  reduce 36 (src line 327)
+
+
+302: shift/reduce conflict (shift 84(0), red'n 63(3)) on '('
+302: shift/reduce conflict (shift 85(0), red'n 63(3)) on '['
+302: shift/reduce conflict (shift 87(0), red'n 63(3)) on '.'
+state 302
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr '?' expr ':' expr.    (63)
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 63 (src line 488)
+
+
+state 303
+	expr:  expr '(' exprs VARARG ')'.    (75)
+
+	.  reduce 75 (src line 548)
+
+
+state 304
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr '[' expr ':' expr.']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_slice:  expr '[' expr ':' expr.':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	':'  shift 353
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	']'  shift 352
+	'.'  shift 87
+	.  error
+
+
+state 305
+	expr_slice:  expr '[' expr ':' ']'.    (128)
+
+	.  reduce 128 (src line 842)
+
+
+state 306
+	expr_slice:  expr '[' ':' expr ']'.    (129)
+
+	.  reduce 129 (src line 846)
+
+
+state 307
+	expr_slice:  expr '[' ':' expr ':'.expr ']' 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 354
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 308
+	stmt_if:  IF expr '{' compstmt '}'.    (34)
+
+	.  reduce 34 (src line 316)
+
+
+309: shift/reduce conflict (shift 5(0), red'n 168(0)) on ';'
+309: shift/reduce conflict (shift 8(0), red'n 168(0)) on '\n'
+state 309
+	stmt_for:  FOR expr_idents IN expr '{'.compstmt '}' 
+	opt_term: .    (168)
+
+	';'  shift 5
+	'\n'  shift 8
+	.  reduce 168 (src line 1079)
+
+	compstmt  goto 355
+	stmts  goto 3
+	opt_term  goto 2
+	term  goto 4
+	newlines  goto 6
+	newline  goto 7
+
+state 310
+	expr_idents:  expr_idents ',' opt_newlines IDENT.    (97)
+
+	.  reduce 97 (src line 652)
+
+
+state 311
+	stmt_for:  FOR expr '{' compstmt '}'.    (39)
+
+	.  reduce 39 (src line 353)
+
+
+state 312
+	stmt_for:  FOR ';' ';' '{' compstmt.'}' 
+
+	'}'  shift 356
+	.  error
+
+
+313: shift/reduce conflict (shift 5(0), red'n 168(0)) on ';'
+313: shift/reduce conflict (shift 8(0), red'n 168(0)) on '\n'
+state 313
+	stmt_for:  FOR ';' ';' expr '{'.compstmt '}' 
+	opt_term: .    (168)
+
+	';'  shift 5
+	'\n'  shift 8
+	.  reduce 168 (src line 1079)
+
+	compstmt  goto 357
+	stmts  goto 3
+	opt_term  goto 2
+	term  goto 4
+	newlines  goto 6
+	newline  goto 7
+
+314: shift/reduce conflict (shift 8(0), red'n 173(0)) on '\n'
+ 314: reduce/reduce conflict  (red'ns 173 and 168) on IDENT
+ 314: reduce/reduce conflict  (red'ns 173 and 168) on NUMBER
+ 314: reduce/reduce conflict  (red'ns 173 and 168) on STRING
+ 314: reduce/reduce conflict  (red'ns 173 and 168) on FUNC
+ 314: reduce/reduce conflict  (red'ns 173 and 168) on NEW
+ 314: reduce/reduce conflict  (red'ns 173 and 168) on TRUE
+ 314: reduce/reduce conflict  (red'ns 173 and 168) on FALSE
+ 314: reduce/reduce conflict  (red'ns 173 and 168) on NIL
+ 314: reduce/reduce conflict  (red'ns 173 and 168) on MAKE
+ 314: reduce/reduce conflict  (red'ns 173 and 168) on OPCHAN
+ 314: reduce/reduce conflict  (red'ns 173 and 168) on LEN
+ 314: reduce/reduce conflict  (red'ns 173 and 168) on MAP
+ 314: reduce/reduce conflict  (red'ns 173 and 168) on IMPORT
+ 314: reduce/reduce conflict  (red'ns 173 and 168) on '-'
+ 314: reduce/reduce conflict  (red'ns 173 and 168) on '^'
+ 314: reduce/reduce conflict  (red'ns 173 and 168) on '*'
+ 314: reduce/reduce conflict  (red'ns 173 and 168) on '&'
+ 314: reduce/reduce conflict  (red'ns 173 and 168) on '{'
+ 314: reduce/reduce conflict  (red'ns 173 and 168) on '}'
+ 314: reduce/reduce conflict  (red'ns 173 and 168) on '('
+ 314: reduce/reduce conflict  (red'ns 173 and 168) on ','
+314: shift/reduce conflict (shift 5(0), red'n 168(0)) on ';'
+ 314: reduce/reduce conflict  (red'ns 173 and 168) on '['
+ 314: reduce/reduce conflict  (red'ns 173 and 168) on '!'
+314: shift/reduce conflict (shift 8(0), red'n 168(0)) on '\n'
+state 314
+	stmt_for:  FOR ';' expr ';' '{'.compstmt '}' 
+	expr:  '{'.opt_newlines expr_map opt_comma_newlines '}' 
+	opt_newlines: .    (173)
+	opt_term: .    (168)
+
+	';'  shift 5
+	'\n'  shift 8
+	.  reduce 168 (src line 1079)
+
+	compstmt  goto 358
+	stmts  goto 3
+	opt_term  goto 2
+	term  goto 4
+	opt_newlines  goto 144
+	newlines  goto 201
+	newline  goto 7
+
+state 315
+	stmt_for:  FOR ';' expr ';' expr.'{' compstmt '}' 
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'{'  shift 359
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  error
+
+
+316: shift/reduce conflict (shift 8(0), red'n 173(0)) on '\n'
+ 316: reduce/reduce conflict  (red'ns 173 and 168) on IDENT
+ 316: reduce/reduce conflict  (red'ns 173 and 168) on NUMBER
+ 316: reduce/reduce conflict  (red'ns 173 and 168) on STRING
+ 316: reduce/reduce conflict  (red'ns 173 and 168) on FUNC
+ 316: reduce/reduce conflict  (red'ns 173 and 168) on NEW
+ 316: reduce/reduce conflict  (red'ns 173 and 168) on TRUE
+ 316: reduce/reduce conflict  (red'ns 173 and 168) on FALSE
+ 316: reduce/reduce conflict  (red'ns 173 and 168) on NIL
+ 316: reduce/reduce conflict  (red'ns 173 and 168) on MAKE
+ 316: reduce/reduce conflict  (red'ns 173 and 168) on OPCHAN
+ 316: reduce/reduce conflict  (red'ns 173 and 168) on LEN
+ 316: reduce/reduce conflict  (red'ns 173 and 168) on MAP
+ 316: reduce/reduce conflict  (red'ns 173 and 168) on IMPORT
+ 316: reduce/reduce conflict  (red'ns 173 and 168) on '-'
+ 316: reduce/reduce conflict  (red'ns 173 and 168) on '^'
+ 316: reduce/reduce conflict  (red'ns 173 and 168) on '*'
+ 316: reduce/reduce conflict  (red'ns 173 and 168) on '&'
+ 316: reduce/reduce conflict  (red'ns 173 and 168) on '{'
+ 316: reduce/reduce conflict  (red'ns 173 and 168) on '}'
+ 316: reduce/reduce conflict  (red'ns 173 and 168) on '('
+ 316: reduce/reduce conflict  (red'ns 173 and 168) on ','
+316: shift/reduce conflict (shift 5(0), red'n 168(0)) on ';'
+ 316: reduce/reduce conflict  (red'ns 173 and 168) on '['
+ 316: reduce/reduce conflict  (red'ns 173 and 168) on '!'
+316: shift/reduce conflict (shift 8(0), red'n 168(0)) on '\n'
+state 316
+	stmt_for:  FOR stmt_var_or_lets ';' ';' '{'.compstmt '}' 
+	expr:  '{'.opt_newlines expr_map opt_comma_newlines '}' 
+	opt_newlines: .    (173)
+	opt_term: .    (168)
+
+	';'  shift 5
+	'\n'  shift 8
+	.  reduce 168 (src line 1079)
+
+	compstmt  goto 360
+	stmts  goto 3
+	opt_term  goto 2
+	term  goto 4
+	opt_newlines  goto 144
+	newlines  goto 201
+	newline  goto 7
+
+state 317
+	stmt_for:  FOR stmt_var_or_lets ';' ';' expr.'{' compstmt '}' 
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'{'  shift 361
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  error
+
+
+state 318
+	stmt_for:  FOR stmt_var_or_lets ';' expr ';'.'{' compstmt '}' 
+	stmt_for:  FOR stmt_var_or_lets ';' expr ';'.expr '{' compstmt '}' 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 362
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 363
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 319
+	stmt_switch:  SWITCH expr '{' opt_newlines stmt_switch_cases.opt_newlines '}' 
+	stmt_switch_cases:  stmt_switch_cases.stmt_switch_case 
+	stmt_switch_cases:  stmt_switch_cases.stmt_switch_default 
+	opt_newlines: .    (173)
+
+	CASE  shift 323
+	DEFAULT  shift 322
+	'\n'  shift 8
+	.  reduce 173 (src line 1088)
+
+	stmt_switch_case  goto 365
+	stmt_switch_default  goto 366
+	opt_newlines  goto 364
+	newlines  goto 126
+	newline  goto 7
+
+state 320
+	stmt_switch_cases:  stmt_switch_default.    (50)
+
+	.  reduce 50 (src line 413)
+
+
+state 321
+	stmt_switch_cases:  stmt_switch_case.    (51)
+
+	.  reduce 51 (src line 417)
+
+
+state 322
+	stmt_switch_default:  DEFAULT.':' compstmt 
+
+	':'  shift 367
+	.  error
+
+
+state 323
+	stmt_switch_case:  CASE.expr ':' compstmt 
+	stmt_switch_case:  CASE.exprs ':' compstmt 
+	exprs: .    (57)
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  reduce 57 (src line 455)
+
+	exprs  goto 369
+	expr  goto 368
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+324: shift/reduce conflict (shift 5(0), red'n 168(0)) on ';'
+324: shift/reduce conflict (shift 8(0), red'n 168(0)) on '\n'
+state 324
+	expr:  FUNC '(' expr_idents ')' '{'.compstmt '}' 
+	opt_term: .    (168)
+
+	';'  shift 5
+	'\n'  shift 8
+	.  reduce 168 (src line 1079)
+
+	compstmt  goto 370
+	stmts  goto 3
+	opt_term  goto 2
+	term  goto 4
+	newlines  goto 6
+	newline  goto 7
+
+state 325
+	expr:  FUNC '(' expr_idents VARARG ')'.'{' compstmt '}' 
+
+	'{'  shift 371
+	.  error
+
+
+state 326
+	expr:  FUNC IDENT '(' expr_idents ')'.'{' compstmt '}' 
+
+	'{'  shift 372
+	.  error
+
+
+state 327
+	expr:  FUNC IDENT '(' expr_idents VARARG.')' '{' compstmt '}' 
+
+	')'  shift 373
+	.  error
+
+
+state 328
+	opt_newlines:  newlines.    (174)
+	newlines:  newlines.newline 
+	opt_comma_newlines:  ',' newlines.    (179)
+
+	'}'  reduce 179 (src line 1100)
+	']'  reduce 179 (src line 1100)
+	'\n'  shift 8
+	.  reduce 174 (src line 1090)
+
+	newline  goto 69
+
+state 329
+	expr:  '[' opt_newlines exprs opt_comma_newlines ']'.    (70)
+
+	.  reduce 70 (src line 523)
+
+
+state 330
+	exprs:  exprs.',' opt_newlines expr 
+	exprs:  exprs.',' opt_newlines expr_ident 
+	expr:  slice_count type_data '{' opt_newlines exprs.opt_comma_newlines '}' 
+	opt_comma_newlines: .    (178)
+
+	','  shift 267
+	'\n'  shift 8
+	.  reduce 178 (src line 1098)
+
+	opt_comma_newlines  goto 374
+	newlines  goto 269
+	newline  goto 7
+
+state 331
+	type_data:  MAP '[' type_data ']'.type_data 
+
+	IDENT  shift 128
+	CHAN  shift 132
+	STRUCT  shift 133
+	MAP  shift 131
+	'*'  shift 129
+	'['  shift 134
+	.  error
+
+	type_data  goto 375
+	slice_count  goto 130
+
+state 332
+	type_data:  STRUCT '{' opt_newlines type_data_struct.opt_newlines '}' 
+	type_data_struct:  type_data_struct.',' opt_newlines IDENT type_data 
+	opt_newlines: .    (173)
+
+	','  shift 377
+	'\n'  shift 8
+	.  reduce 173 (src line 1088)
+
+	opt_newlines  goto 376
+	newlines  goto 126
+	newline  goto 7
+
+state 333
+	type_data_struct:  IDENT.type_data 
+
+	IDENT  shift 128
+	CHAN  shift 132
+	STRUCT  shift 133
+	MAP  shift 131
+	'*'  shift 129
+	'['  shift 134
+	.  error
+
+	type_data  goto 378
+	slice_count  goto 130
+
+state 334
+	expr:  IDENT '(' exprs VARARG ')'.    (73)
+
+	.  reduce 73 (src line 538)
+
+
+state 335
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr_ident '[' expr ':' expr.']' 
+	expr_slice:  expr_ident '[' expr ':' expr.':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	':'  shift 380
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	']'  shift 379
+	'.'  shift 87
+	.  error
+
+
+state 336
+	expr_slice:  expr_ident '[' expr ':' ']'.    (123)
+
+	.  reduce 123 (src line 822)
+
+
+state 337
+	expr_slice:  expr_ident '[' ':' expr ']'.    (124)
+
+	.  reduce 124 (src line 826)
+
+
+state 338
+	expr_slice:  expr_ident '[' ':' expr ':'.expr ']' 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 381
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 339
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  MAKE '(' type_data ',' expr.')' 
+	expr:  MAKE '(' type_data ',' expr.',' expr ')' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	')'  shift 382
+	','  shift 383
+	'['  shift 85
+	'.'  shift 87
+	.  error
+
+
+state 340
+	expr:  MAKE '(' TYPE IDENT ','.expr ')' 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 384
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 341
+	expr:  MAP '{' opt_newlines expr_map opt_comma_newlines.'}' 
+
+	'}'  shift 385
+	.  error
+
+
+state 342
+	expr:  MAP '[' type_data ']' type_data.'{' opt_newlines expr_map opt_comma_newlines '}' 
+	type_data:  type_data.'.' IDENT 
+
+	'{'  shift 386
+	'.'  shift 214
+	.  error
+
+
+state 343
+	expr:  '{' opt_newlines expr_map opt_comma_newlines '}'.    (89)
+
+	.  reduce 89 (src line 625)
+
+
+state 344
+	expr_map:  expr_map ',' opt_newlines.expr ':' expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 387
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 345
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_map:  expr ':' expr.    (120)
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 120 (src line 804)
+
+
+state 346
+	stmt:  TRY '{' compstmt '}' CATCH IDENT.'{' compstmt '}' FINALLY '{' compstmt '}' 
+	stmt:  TRY '{' compstmt '}' CATCH IDENT.'{' compstmt '}' 
+
+	'{'  shift 388
+	.  error
+
+
+347: shift/reduce conflict (shift 5(0), red'n 168(0)) on ';'
+347: shift/reduce conflict (shift 8(0), red'n 168(0)) on '\n'
+state 347
+	stmt:  TRY '{' compstmt '}' CATCH '{'.compstmt '}' FINALLY '{' compstmt '}' 
+	stmt:  TRY '{' compstmt '}' CATCH '{'.compstmt '}' 
+	opt_term: .    (168)
+
+	';'  shift 5
+	'\n'  shift 8
+	.  reduce 168 (src line 1079)
+
+	compstmt  goto 389
+	stmts  goto 3
+	opt_term  goto 2
+	term  goto 4
+	newlines  goto 6
+	newline  goto 7
+
+state 348
+	stmt:  GO IDENT '(' exprs VARARG ')'.    (16)
+	expr:  IDENT '(' exprs VARARG ')'.    (73)
+
+	$end  reduce 16 (src line 195)
+	CASE  reduce 16 (src line 195)
+	DEFAULT  reduce 16 (src line 195)
+	'}'  reduce 16 (src line 195)
+	';'  reduce 16 (src line 195)
+	'\n'  reduce 16 (src line 195)
+	.  reduce 73 (src line 538)
+
+
+state 349
+	stmt:  GO expr '(' exprs VARARG ')'.    (18)
+	expr:  expr '(' exprs VARARG ')'.    (75)
+
+	$end  reduce 18 (src line 205)
+	CASE  reduce 18 (src line 205)
+	DEFAULT  reduce 18 (src line 205)
+	'}'  reduce 18 (src line 205)
+	';'  reduce 18 (src line 205)
+	'\n'  reduce 18 (src line 205)
+	.  reduce 75 (src line 548)
+
+
+state 350
+	stmt:  DELETE '(' expr ',' expr ')'.    (21)
+
+	.  reduce 21 (src line 220)
+
+
+state 351
+	stmt_if:  stmt_if ELSE IF expr '{' compstmt.'}' 
+
+	'}'  shift 390
+	.  error
+
+
+state 352
+	expr_slice:  expr '[' expr ':' expr ']'.    (127)
+
+	.  reduce 127 (src line 838)
+
+
+state 353
+	expr_slice:  expr '[' expr ':' expr ':'.expr ']' 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 391
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 354
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr '[' ':' expr ':' expr.']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	']'  shift 392
+	'.'  shift 87
+	.  error
+
+
+state 355
+	stmt_for:  FOR expr_idents IN expr '{' compstmt.'}' 
+
+	'}'  shift 393
+	.  error
+
+
+state 356
+	stmt_for:  FOR ';' ';' '{' compstmt '}'.    (40)
+
+	.  reduce 40 (src line 358)
+
+
+state 357
+	stmt_for:  FOR ';' ';' expr '{' compstmt.'}' 
+
+	'}'  shift 394
+	.  error
+
+
+state 358
+	stmt_for:  FOR ';' expr ';' '{' compstmt.'}' 
+
+	'}'  shift 395
+	.  error
+
+
+359: shift/reduce conflict (shift 5(0), red'n 168(0)) on ';'
+359: shift/reduce conflict (shift 8(0), red'n 168(0)) on '\n'
+state 359
+	stmt_for:  FOR ';' expr ';' expr '{'.compstmt '}' 
+	opt_term: .    (168)
+
+	';'  shift 5
+	'\n'  shift 8
+	.  reduce 168 (src line 1079)
+
+	compstmt  goto 396
+	stmts  goto 3
+	opt_term  goto 2
+	term  goto 4
+	newlines  goto 6
+	newline  goto 7
+
+state 360
+	stmt_for:  FOR stmt_var_or_lets ';' ';' '{' compstmt.'}' 
+
+	'}'  shift 397
+	.  error
+
+
+361: shift/reduce conflict (shift 5(0), red'n 168(0)) on ';'
+361: shift/reduce conflict (shift 8(0), red'n 168(0)) on '\n'
+state 361
+	stmt_for:  FOR stmt_var_or_lets ';' ';' expr '{'.compstmt '}' 
+	opt_term: .    (168)
+
+	';'  shift 5
+	'\n'  shift 8
+	.  reduce 168 (src line 1079)
+
+	compstmt  goto 398
+	stmts  goto 3
+	opt_term  goto 2
+	term  goto 4
+	newlines  goto 6
+	newline  goto 7
+
+362: shift/reduce conflict (shift 8(0), red'n 173(0)) on '\n'
+ 362: reduce/reduce conflict  (red'ns 173 and 168) on IDENT
+ 362: reduce/reduce conflict  (red'ns 173 and 168) on NUMBER
+ 362: reduce/reduce conflict  (red'ns 173 and 168) on STRING
+ 362: reduce/reduce conflict  (red'ns 173 and 168) on FUNC
+ 362: reduce/reduce conflict  (red'ns 173 and 168) on NEW
+ 362: reduce/reduce conflict  (red'ns 173 and 168) on TRUE
+ 362: reduce/reduce conflict  (red'ns 173 and 168) on FALSE
+ 362: reduce/reduce conflict  (red'ns 173 and 168) on NIL
+ 362: reduce/reduce conflict  (red'ns 173 and 168) on MAKE
+ 362: reduce/reduce conflict  (red'ns 173 and 168) on OPCHAN
+ 362: reduce/reduce conflict  (red'ns 173 and 168) on LEN
+ 362: reduce/reduce conflict  (red'ns 173 and 168) on MAP
+ 362: reduce/reduce conflict  (red'ns 173 and 168) on IMPORT
+ 362: reduce/reduce conflict  (red'ns 173 and 168) on '-'
+ 362: reduce/reduce conflict  (red'ns 173 and 168) on '^'
+ 362: reduce/reduce conflict  (red'ns 173 and 168) on '*'
+ 362: reduce/reduce conflict  (red'ns 173 and 168) on '&'
+ 362: reduce/reduce conflict  (red'ns 173 and 168) on '{'
+ 362: reduce/reduce conflict  (red'ns 173 and 168) on '}'
+ 362: reduce/reduce conflict  (red'ns 173 and 168) on '('
+ 362: reduce/reduce conflict  (red'ns 173 and 168) on ','
+362: shift/reduce conflict (shift 5(0), red'n 168(0)) on ';'
+ 362: reduce/reduce conflict  (red'ns 173 and 168) on '['
+ 362: reduce/reduce conflict  (red'ns 173 and 168) on '!'
+362: shift/reduce conflict (shift 8(0), red'n 168(0)) on '\n'
+state 362
+	stmt_for:  FOR stmt_var_or_lets ';' expr ';' '{'.compstmt '}' 
+	expr:  '{'.opt_newlines expr_map opt_comma_newlines '}' 
+	opt_newlines: .    (173)
+	opt_term: .    (168)
+
+	';'  shift 5
+	'\n'  shift 8
+	.  reduce 168 (src line 1079)
+
+	compstmt  goto 399
+	stmts  goto 3
+	opt_term  goto 2
+	term  goto 4
+	opt_newlines  goto 144
+	newlines  goto 201
+	newline  goto 7
+
+state 363
+	stmt_for:  FOR stmt_var_or_lets ';' expr ';' expr.'{' compstmt '}' 
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'{'  shift 400
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  error
+
+
+state 364
+	stmt_switch:  SWITCH expr '{' opt_newlines stmt_switch_cases opt_newlines.'}' 
+
+	'}'  shift 401
+	.  error
+
+
+state 365
+	stmt_switch_cases:  stmt_switch_cases stmt_switch_case.    (52)
+
+	.  reduce 52 (src line 421)
+
+
+state 366
+	stmt_switch_cases:  stmt_switch_cases stmt_switch_default.    (53)
+
+	.  reduce 53 (src line 427)
+
+
+367: shift/reduce conflict (shift 5(0), red'n 168(0)) on ';'
+367: shift/reduce conflict (shift 8(0), red'n 168(0)) on '\n'
+state 367
+	stmt_switch_default:  DEFAULT ':'.compstmt 
+	opt_term: .    (168)
+
+	';'  shift 5
+	'\n'  shift 8
+	.  reduce 168 (src line 1079)
+
+	compstmt  goto 402
+	stmts  goto 3
+	opt_term  goto 2
+	term  goto 4
+	newlines  goto 6
+	newline  goto 7
+
+368: shift/reduce conflict (shift 403(3), red'n 58(0)) on ':'
+state 368
+	stmt_switch_case:  CASE expr.':' compstmt 
+	exprs:  expr.    (58)
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	':'  shift 403
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 58 (src line 460)
+
+
+state 369
+	stmt_switch_case:  CASE exprs.':' compstmt 
+	exprs:  exprs.',' opt_newlines expr 
+	exprs:  exprs.',' opt_newlines expr_ident 
+
+	':'  shift 404
+	','  shift 149
+	.  error
+
+
+state 370
+	expr:  FUNC '(' expr_idents ')' '{' compstmt.'}' 
+
+	'}'  shift 405
+	.  error
+
+
+371: shift/reduce conflict (shift 5(0), red'n 168(0)) on ';'
+371: shift/reduce conflict (shift 8(0), red'n 168(0)) on '\n'
+state 371
+	expr:  FUNC '(' expr_idents VARARG ')' '{'.compstmt '}' 
+	opt_term: .    (168)
+
+	';'  shift 5
+	'\n'  shift 8
+	.  reduce 168 (src line 1079)
+
+	compstmt  goto 406
+	stmts  goto 3
+	opt_term  goto 2
+	term  goto 4
+	newlines  goto 6
+	newline  goto 7
+
+372: shift/reduce conflict (shift 5(0), red'n 168(0)) on ';'
+372: shift/reduce conflict (shift 8(0), red'n 168(0)) on '\n'
+state 372
+	expr:  FUNC IDENT '(' expr_idents ')' '{'.compstmt '}' 
+	opt_term: .    (168)
+
+	';'  shift 5
+	'\n'  shift 8
+	.  reduce 168 (src line 1079)
+
+	compstmt  goto 407
+	stmts  goto 3
+	opt_term  goto 2
+	term  goto 4
+	newlines  goto 6
+	newline  goto 7
+
+state 373
+	expr:  FUNC IDENT '(' expr_idents VARARG ')'.'{' compstmt '}' 
+
+	'{'  shift 408
+	.  error
+
+
+state 374
+	expr:  slice_count type_data '{' opt_newlines exprs opt_comma_newlines.'}' 
+
+	'}'  shift 409
+	.  error
+
+
+375: shift/reduce conflict (shift 214(0), red'n 102(0)) on '.'
+state 375
+	type_data:  type_data.'.' IDENT 
+	type_data:  MAP '[' type_data ']' type_data.    (102)
+
+	'.'  shift 214
+	.  reduce 102 (src line 693)
+
+
+state 376
+	type_data:  STRUCT '{' opt_newlines type_data_struct opt_newlines.'}' 
+
+	'}'  shift 410
+	.  error
+
+
+state 377
+	type_data_struct:  type_data_struct ','.opt_newlines IDENT type_data 
+	opt_newlines: .    (173)
+
+	'\n'  shift 8
+	.  reduce 173 (src line 1088)
+
+	opt_newlines  goto 411
+	newlines  goto 126
+	newline  goto 7
+
+state 378
+	type_data:  type_data.'.' IDENT 
+	type_data_struct:  IDENT type_data.    (105)
+
+	'.'  shift 214
+	.  reduce 105 (src line 711)
+
+
+state 379
+	expr_slice:  expr_ident '[' expr ':' expr ']'.    (122)
+
+	.  reduce 122 (src line 817)
+
+
+state 380
+	expr_slice:  expr_ident '[' expr ':' expr ':'.expr ']' 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 412
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 381
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr_ident '[' ':' expr ':' expr.']' 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	']'  shift 413
+	'.'  shift 87
+	.  error
+
+
+state 382
+	expr:  MAKE '(' type_data ',' expr ')'.    (83)
+
+	.  reduce 83 (src line 593)
+
+
+state 383
+	expr:  MAKE '(' type_data ',' expr ','.expr ')' 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 414
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 384
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  MAKE '(' TYPE IDENT ',' expr.')' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	')'  shift 415
+	'['  shift 85
+	'.'  shift 87
+	.  error
+
+
+state 385
+	expr:  MAP '{' opt_newlines expr_map opt_comma_newlines '}'.    (87)
+
+	.  reduce 87 (src line 613)
+
+
+386: shift/reduce conflict (shift 8(0), red'n 173(0)) on '\n'
+state 386
+	expr:  MAP '[' type_data ']' type_data '{'.opt_newlines expr_map opt_comma_newlines '}' 
+	opt_newlines: .    (173)
+
+	'\n'  shift 8
+	.  reduce 173 (src line 1088)
+
+	opt_newlines  goto 416
+	newlines  goto 126
+	newline  goto 7
+
+state 387
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_map:  expr_map ',' opt_newlines expr.':' expr 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	':'  shift 417
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  error
+
+
+388: shift/reduce conflict (shift 5(0), red'n 168(0)) on ';'
+388: shift/reduce conflict (shift 8(0), red'n 168(0)) on '\n'
+state 388
+	stmt:  TRY '{' compstmt '}' CATCH IDENT '{'.compstmt '}' FINALLY '{' compstmt '}' 
+	stmt:  TRY '{' compstmt '}' CATCH IDENT '{'.compstmt '}' 
+	opt_term: .    (168)
+
+	';'  shift 5
+	'\n'  shift 8
+	.  reduce 168 (src line 1079)
+
+	compstmt  goto 418
+	stmts  goto 3
+	opt_term  goto 2
+	term  goto 4
+	newlines  goto 6
+	newline  goto 7
+
+state 389
+	stmt:  TRY '{' compstmt '}' CATCH '{' compstmt.'}' FINALLY '{' compstmt '}' 
+	stmt:  TRY '{' compstmt '}' CATCH '{' compstmt.'}' 
+
+	'}'  shift 419
+	.  error
+
+
+state 390
+	stmt_if:  stmt_if ELSE IF expr '{' compstmt '}'.    (35)
+
+	.  reduce 35 (src line 322)
+
+
+state 391
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_slice:  expr '[' expr ':' expr ':' expr.']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	']'  shift 420
+	'.'  shift 87
+	.  error
+
+
+state 392
+	expr_slice:  expr '[' ':' expr ':' expr ']'.    (130)
+
+	.  reduce 130 (src line 850)
+
+
+state 393
+	stmt_for:  FOR expr_idents IN expr '{' compstmt '}'.    (38)
+
+	.  reduce 38 (src line 342)
+
+
+state 394
+	stmt_for:  FOR ';' ';' expr '{' compstmt '}'.    (41)
+
+	.  reduce 41 (src line 363)
+
+
+state 395
+	stmt_for:  FOR ';' expr ';' '{' compstmt '}'.    (42)
+
+	.  reduce 42 (src line 368)
+
+
+state 396
+	stmt_for:  FOR ';' expr ';' expr '{' compstmt.'}' 
+
+	'}'  shift 421
+	.  error
+
+
+state 397
+	stmt_for:  FOR stmt_var_or_lets ';' ';' '{' compstmt '}'.    (44)
+
+	.  reduce 44 (src line 378)
+
+
+state 398
+	stmt_for:  FOR stmt_var_or_lets ';' ';' expr '{' compstmt.'}' 
+
+	'}'  shift 422
+	.  error
+
+
+state 399
+	stmt_for:  FOR stmt_var_or_lets ';' expr ';' '{' compstmt.'}' 
+
+	'}'  shift 423
+	.  error
+
+
+400: shift/reduce conflict (shift 5(0), red'n 168(0)) on ';'
+400: shift/reduce conflict (shift 8(0), red'n 168(0)) on '\n'
+state 400
+	stmt_for:  FOR stmt_var_or_lets ';' expr ';' expr '{'.compstmt '}' 
+	opt_term: .    (168)
+
+	';'  shift 5
+	'\n'  shift 8
+	.  reduce 168 (src line 1079)
+
+	compstmt  goto 424
+	stmts  goto 3
+	opt_term  goto 2
+	term  goto 4
+	newlines  goto 6
+	newline  goto 7
+
+state 401
+	stmt_switch:  SWITCH expr '{' opt_newlines stmt_switch_cases opt_newlines '}'.    (48)
+
+	.  reduce 48 (src line 399)
+
+
+state 402
+	stmt_switch_default:  DEFAULT ':' compstmt.    (56)
+
+	.  reduce 56 (src line 448)
+
+
+403: shift/reduce conflict (shift 5(0), red'n 168(0)) on ';'
+403: shift/reduce conflict (shift 8(0), red'n 168(0)) on '\n'
+state 403
+	stmt_switch_case:  CASE expr ':'.compstmt 
+	opt_term: .    (168)
+
+	';'  shift 5
+	'\n'  shift 8
+	.  reduce 168 (src line 1079)
+
+	compstmt  goto 425
+	stmts  goto 3
+	opt_term  goto 2
+	term  goto 4
+	newlines  goto 6
+	newline  goto 7
+
+404: shift/reduce conflict (shift 5(0), red'n 168(0)) on ';'
+404: shift/reduce conflict (shift 8(0), red'n 168(0)) on '\n'
+state 404
+	stmt_switch_case:  CASE exprs ':'.compstmt 
+	opt_term: .    (168)
+
+	';'  shift 5
+	'\n'  shift 8
+	.  reduce 168 (src line 1079)
+
+	compstmt  goto 426
+	stmts  goto 3
+	opt_term  goto 2
+	term  goto 4
+	newlines  goto 6
+	newline  goto 7
+
+state 405
+	expr:  FUNC '(' expr_idents ')' '{' compstmt '}'.    (65)
+
+	.  reduce 65 (src line 498)
+
+
+state 406
+	expr:  FUNC '(' expr_idents VARARG ')' '{' compstmt.'}' 
+
+	'}'  shift 427
+	.  error
+
+
+state 407
+	expr:  FUNC IDENT '(' expr_idents ')' '{' compstmt.'}' 
+
+	'}'  shift 428
+	.  error
+
+
+408: shift/reduce conflict (shift 5(0), red'n 168(0)) on ';'
+408: shift/reduce conflict (shift 8(0), red'n 168(0)) on '\n'
+state 408
+	expr:  FUNC IDENT '(' expr_idents VARARG ')' '{'.compstmt '}' 
+	opt_term: .    (168)
+
+	';'  shift 5
+	'\n'  shift 8
+	.  reduce 168 (src line 1079)
+
+	compstmt  goto 429
+	stmts  goto 3
+	opt_term  goto 2
+	term  goto 4
+	newlines  goto 6
+	newline  goto 7
+
+state 409
+	expr:  slice_count type_data '{' opt_newlines exprs opt_comma_newlines '}'.    (71)
+
+	.  reduce 71 (src line 528)
+
+
+state 410
+	type_data:  STRUCT '{' opt_newlines type_data_struct opt_newlines '}'.    (104)
+
+	.  reduce 104 (src line 706)
+
+
+state 411
+	type_data_struct:  type_data_struct ',' opt_newlines.IDENT type_data 
+
+	IDENT  shift 430
+	.  error
+
+
+state 412
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr_ident '[' expr ':' expr ':' expr.']' 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	']'  shift 431
+	'.'  shift 87
+	.  error
+
+
+state 413
+	expr_slice:  expr_ident '[' ':' expr ':' expr ']'.    (125)
+
+	.  reduce 125 (src line 830)
+
+
+state 414
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  MAKE '(' type_data ',' expr ',' expr.')' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	')'  shift 432
+	'['  shift 85
+	'.'  shift 87
+	.  error
+
+
+state 415
+	expr:  MAKE '(' TYPE IDENT ',' expr ')'.    (85)
+
+	.  reduce 85 (src line 603)
+
+
+state 416
+	expr:  MAP '[' type_data ']' type_data '{' opt_newlines.expr_map opt_comma_newlines '}' 
+	expr_map: .    (119)
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  reduce 119 (src line 799)
+
+	expr  goto 233
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_map  goto 433
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 417
+	expr_map:  expr_map ',' opt_newlines expr ':'.expr 
+
+	IDENT  shift 35
+	NUMBER  shift 52
+	STRING  shift 53
+	FUNC  shift 31
+	NEW  shift 39
+	TRUE  shift 54
+	FALSE  shift 55
+	NIL  shift 56
+	MAKE  shift 40
+	OPCHAN  shift 57
+	LEN  shift 37
+	MAP  shift 41
+	IMPORT  shift 38
+	'-'  shift 51
+	'^'  shift 59
+	'*'  shift 61
+	'&'  shift 60
+	'{'  shift 42
+	'('  shift 34
+	'['  shift 32
+	'!'  shift 58
+	.  error
+
+	expr  goto 434
+	slice_count  goto 33
+	expr_member_or_ident  goto 29
+	expr_member  goto 50
+	expr_ident  goto 36
+	expr_literals  goto 30
+	expr_slice  goto 43
+	expr_chan  goto 44
+	expr_unary  goto 45
+	expr_binary  goto 46
+	expr_lets  goto 47
+	op_binary  goto 65
+	op_comparison  goto 64
+	op_add  goto 63
+	op_multiply  goto 62
+
+state 418
+	stmt:  TRY '{' compstmt '}' CATCH IDENT '{' compstmt.'}' FINALLY '{' compstmt '}' 
+	stmt:  TRY '{' compstmt '}' CATCH IDENT '{' compstmt.'}' 
+
+	'}'  shift 435
+	.  error
+
+
+state 419
+	stmt:  TRY '{' compstmt '}' CATCH '{' compstmt '}'.FINALLY '{' compstmt '}' 
+	stmt:  TRY '{' compstmt '}' CATCH '{' compstmt '}'.    (15)
+
+	FINALLY  shift 436
+	.  reduce 15 (src line 190)
+
+
+state 420
+	expr_slice:  expr '[' expr ':' expr ':' expr ']'.    (131)
+
+	.  reduce 131 (src line 854)
+
+
+state 421
+	stmt_for:  FOR ';' expr ';' expr '{' compstmt '}'.    (43)
+
+	.  reduce 43 (src line 373)
+
+
+state 422
+	stmt_for:  FOR stmt_var_or_lets ';' ';' expr '{' compstmt '}'.    (45)
+
+	.  reduce 45 (src line 383)
+
+
+state 423
+	stmt_for:  FOR stmt_var_or_lets ';' expr ';' '{' compstmt '}'.    (46)
+
+	.  reduce 46 (src line 388)
+
+
+state 424
+	stmt_for:  FOR stmt_var_or_lets ';' expr ';' expr '{' compstmt.'}' 
+
+	'}'  shift 437
+	.  error
+
+
+state 425
+	stmt_switch_case:  CASE expr ':' compstmt.    (54)
+
+	.  reduce 54 (src line 436)
+
+
+state 426
+	stmt_switch_case:  CASE exprs ':' compstmt.    (55)
+
+	.  reduce 55 (src line 442)
+
+
+state 427
+	expr:  FUNC '(' expr_idents VARARG ')' '{' compstmt '}'.    (66)
+
+	.  reduce 66 (src line 503)
+
+
+state 428
+	expr:  FUNC IDENT '(' expr_idents ')' '{' compstmt '}'.    (67)
+
+	.  reduce 67 (src line 508)
+
+
+state 429
+	expr:  FUNC IDENT '(' expr_idents VARARG ')' '{' compstmt.'}' 
+
+	'}'  shift 438
+	.  error
+
+
+state 430
+	type_data_struct:  type_data_struct ',' opt_newlines IDENT.type_data 
+
+	IDENT  shift 128
+	CHAN  shift 132
+	STRUCT  shift 133
+	MAP  shift 131
+	'*'  shift 129
+	'['  shift 134
+	.  error
+
+	type_data  goto 439
+	slice_count  goto 130
+
+state 431
+	expr_slice:  expr_ident '[' expr ':' expr ':' expr ']'.    (126)
+
+	.  reduce 126 (src line 834)
+
+
+state 432
+	expr:  MAKE '(' type_data ',' expr ',' expr ')'.    (84)
+
+	.  reduce 84 (src line 598)
+
+
+state 433
+	expr:  MAP '[' type_data ']' type_data '{' opt_newlines expr_map.opt_comma_newlines '}' 
+	expr_map:  expr_map.',' opt_newlines expr ':' expr 
+	opt_comma_newlines: .    (178)
+
+	','  shift 288
+	'\n'  shift 8
+	.  reduce 178 (src line 1098)
+
+	opt_comma_newlines  goto 440
+	newlines  goto 269
+	newline  goto 7
+
+state 434
+	expr:  expr.'?' expr ':' expr 
+	expr:  expr.NILCOALESCE expr 
+	expr:  expr.'(' exprs VARARG ')' 
+	expr:  expr.'(' exprs ')' 
+	expr:  expr.'[' expr ']' 
+	expr:  expr.IN expr 
+	expr_member:  expr.'.' IDENT 
+	expr_map:  expr_map ',' opt_newlines expr ':' expr.    (121)
+	expr_slice:  expr.'[' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' ']' 
+	expr_slice:  expr.'[' ':' expr ']' 
+	expr_slice:  expr.'[' ':' expr ':' expr ']' 
+	expr_slice:  expr.'[' expr ':' expr ':' expr ']' 
+	expr_chan:  expr.OPCHAN expr 
+	expr_lets:  expr.PLUSPLUS 
+	expr_lets:  expr.MINUSMINUS 
+	expr_lets:  expr.PLUSEQ expr 
+	expr_lets:  expr.MINUSEQ expr 
+	expr_lets:  expr.OREQ expr 
+	expr_lets:  expr.MULEQ expr 
+	expr_lets:  expr.DIVEQ expr 
+	expr_lets:  expr.ANDEQ expr 
+	op_multiply:  expr.'*' expr 
+	op_multiply:  expr.'/' expr 
+	op_multiply:  expr.'%' expr 
+	op_multiply:  expr.SHIFTLEFT expr 
+	op_multiply:  expr.SHIFTRIGHT expr 
+	op_multiply:  expr.'&' expr 
+	op_add:  expr.'+' expr 
+	op_add:  expr.'-' expr 
+	op_add:  expr.'|' expr 
+	op_comparison:  expr.EQEQ expr 
+	op_comparison:  expr.NEQ expr 
+	op_comparison:  expr.'<' expr 
+	op_comparison:  expr.LE expr 
+	op_comparison:  expr.'>' expr 
+	op_comparison:  expr.GE expr 
+	op_binary:  expr.ANDAND expr 
+	op_binary:  expr.OROR expr 
+
+	IN  shift 86
+	EQEQ  shift 106
+	NEQ  shift 107
+	GE  shift 111
+	LE  shift 109
+	OROR  shift 113
+	ANDAND  shift 112
+	NILCOALESCE  shift 83
+	PLUSEQ  shift 91
+	MINUSEQ  shift 92
+	MULEQ  shift 94
+	DIVEQ  shift 95
+	ANDEQ  shift 96
+	OREQ  shift 93
+	PLUSPLUS  shift 89
+	MINUSMINUS  shift 90
+	SHIFTLEFT  shift 100
+	SHIFTRIGHT  shift 101
+	OPCHAN  shift 88
+	'?'  shift 82
+	'<'  shift 108
+	'>'  shift 110
+	'+'  shift 103
+	'-'  shift 104
+	'|'  shift 105
+	'*'  shift 97
+	'/'  shift 98
+	'%'  shift 99
+	'&'  shift 102
+	'('  shift 84
+	'['  shift 85
+	'.'  shift 87
+	.  reduce 121 (src line 808)
+
+
+state 435
+	stmt:  TRY '{' compstmt '}' CATCH IDENT '{' compstmt '}'.FINALLY '{' compstmt '}' 
+	stmt:  TRY '{' compstmt '}' CATCH IDENT '{' compstmt '}'.    (14)
+
+	FINALLY  shift 441
+	.  reduce 14 (src line 185)
+
+
+state 436
+	stmt:  TRY '{' compstmt '}' CATCH '{' compstmt '}' FINALLY.'{' compstmt '}' 
+
+	'{'  shift 442
+	.  error
+
+
+state 437
+	stmt_for:  FOR stmt_var_or_lets ';' expr ';' expr '{' compstmt '}'.    (47)
+
+	.  reduce 47 (src line 393)
+
+
+state 438
+	expr:  FUNC IDENT '(' expr_idents VARARG ')' '{' compstmt '}'.    (68)
+
+	.  reduce 68 (src line 513)
+
+
+state 439
+	type_data:  type_data.'.' IDENT 
+	type_data_struct:  type_data_struct ',' opt_newlines IDENT type_data.    (106)
+
+	'.'  shift 214
+	.  reduce 106 (src line 716)
+
+
+state 440
+	expr:  MAP '[' type_data ']' type_data '{' opt_newlines expr_map opt_comma_newlines.'}' 
+
+	'}'  shift 443
+	.  error
+
+
+state 441
+	stmt:  TRY '{' compstmt '}' CATCH IDENT '{' compstmt '}' FINALLY.'{' compstmt '}' 
+
+	'{'  shift 444
+	.  error
+
+
+442: shift/reduce conflict (shift 5(0), red'n 168(0)) on ';'
+442: shift/reduce conflict (shift 8(0), red'n 168(0)) on '\n'
+state 442
+	stmt:  TRY '{' compstmt '}' CATCH '{' compstmt '}' FINALLY '{'.compstmt '}' 
+	opt_term: .    (168)
+
+	';'  shift 5
+	'\n'  shift 8
+	.  reduce 168 (src line 1079)
+
+	compstmt  goto 445
+	stmts  goto 3
+	opt_term  goto 2
+	term  goto 4
+	newlines  goto 6
+	newline  goto 7
+
+state 443
+	expr:  MAP '[' type_data ']' type_data '{' opt_newlines expr_map opt_comma_newlines '}'.    (88)
+
+	.  reduce 88 (src line 619)
+
+
+444: shift/reduce conflict (shift 5(0), red'n 168(0)) on ';'
+444: shift/reduce conflict (shift 8(0), red'n 168(0)) on '\n'
+state 444
+	stmt:  TRY '{' compstmt '}' CATCH IDENT '{' compstmt '}' FINALLY '{'.compstmt '}' 
+	opt_term: .    (168)
+
+	';'  shift 5
+	'\n'  shift 8
+	.  reduce 168 (src line 1079)
+
+	compstmt  goto 446
+	stmts  goto 3
+	opt_term  goto 2
+	term  goto 4
+	newlines  goto 6
+	newline  goto 7
+
+state 445
+	stmt:  TRY '{' compstmt '}' CATCH '{' compstmt '}' FINALLY '{' compstmt.'}' 
+
+	'}'  shift 447
+	.  error
+
+
+state 446
+	stmt:  TRY '{' compstmt '}' CATCH IDENT '{' compstmt '}' FINALLY '{' compstmt.'}' 
+
+	'}'  shift 448
+	.  error
+
+
+state 447
+	stmt:  TRY '{' compstmt '}' CATCH '{' compstmt '}' FINALLY '{' compstmt '}'.    (13)
+
+	.  reduce 13 (src line 180)
+
+
+state 448
+	stmt:  TRY '{' compstmt '}' CATCH IDENT '{' compstmt '}' FINALLY '{' compstmt '}'.    (12)
+
+	.  reduce 12 (src line 175)
+
+
+83 terminals, 39 nonterminals
+182 grammar rules, 449/16000 states
+193 shift/reduce, 211 reduce/reduce conflicts reported
+188 working sets used
+memory: parser 1991/240000
+411 extra closures
+4162 shift entries, 58 exceptions
+239 goto entries
+1392 entries saved by goto default
+Optimizer space used: output 3907/240000
+3907 table entries, 1818 zero
+maximum spread: 83, maximum offset: 444

--- a/vm/vmStmt.go
+++ b/vm/vmStmt.go
@@ -139,6 +139,11 @@ func (runInfo *runInfoStruct) runSingleStmt() {
 
 	// LetsStmt
 	case *ast.LetsStmt:
+		if len(stmt.LHSS) < 1 || len(stmt.RHSS) < 1 {
+			runInfo.err = newStringError(stmt, "invalid operation")
+			runInfo.rv = nilValue
+			return
+		}
 		// get right side expression values
 		rvs := make([]reflect.Value, len(stmt.RHSS))
 		var i int

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -232,6 +232,9 @@ func TestVar(t *testing.T) {
 		{Script: `a := 1`, ParseError: fmt.Errorf("syntax error")},
 		{Script: `var a := 1`, ParseError: fmt.Errorf("syntax error")},
 		{Script: `y = z`, RunError: fmt.Errorf("undefined symbol 'z'")},
+		{Script: `= 1`, ParseError: fmt.Errorf("missing expressions on left side of '='"), RunError: fmt.Errorf("invalid operation")},
+		{Script: `= 1, 2`, ParseError: fmt.Errorf("missing expressions on left side of '='"), RunError: fmt.Errorf("invalid operation")},
+		{Script: `a, b =`, ParseError: fmt.Errorf("missing expressions on right side of '='"), RunError: fmt.Errorf("invalid operation")},
 
 		{Script: `a = nil`, RunOutput: nil, Output: map[string]interface{}{"a": nil}},
 		{Script: `a = true`, RunOutput: true, Output: map[string]interface{}{"a": true}},
@@ -617,6 +620,7 @@ func TestChan(t *testing.T) {
 
 	tests = []Test{
 		{Script: `a = make(chan int64, 2); a <- 1; = <- a`, ParseError: fmt.Errorf("missing expressions on left side of channel operator"), RunError: fmt.Errorf("invalid operation")},
+		{Script: `a = make(chan int64, 2); a <- 1; x, y, z = <- a`, ParseError: fmt.Errorf("too many expressions on left side of channel operator"), RunError: fmt.Errorf("invalid operation")},
 
 		{Script: `<- 1++`, RunError: fmt.Errorf("invalid operation")},
 		{Script: `1++ <- 1`, RunError: fmt.Errorf("invalid operation")},


### PR DESCRIPTION
Found by fuzzing:

- `= 1` crashed the parser indexing an empty expression list in the `exprs '=' exprs` action
- `a, b =` crashed the VM indexing an empty right-hand-side value list in LetsStmt
- `x, y, z = <- ch` silently did nothing because the grammar action left the statement unset for 3+ left-hand expressions

These now report parse errors, and the VM guards LetsStmt against empty expression lists.