### PR TITLE
Increase interactive test read timeout to avoid CI flakiness

### DIFF
--- a/anko_test.go
+++ b/anko_test.go
@@ -144,7 +144,7 @@ func runInteractiveTests(t *testing.T, tests []testInteractive) {
 	chanQuit := make(chan struct{}, 1)
 	chanErr := make(chan string, 3)
 	chanOut := make(chan string, 3)
-	readTimeout := 10 * time.Millisecond
+	readTimeout := 500 * time.Millisecond
 	var dataErr string
 	var dataOut string
 


### PR DESCRIPTION
TestRunInteractive used a 10ms read timeout, which intermittently fails on loaded CI runners (seen on windows-latest with Go 1.26). Raise it to 500ms; the test now takes ~3.5s instead of ~0.5s locally, in exchange for reliability.