### PR TITLE
Return errors instead of panicking on unhashable map keys

### DIFF
--- a/vm/vm.go
+++ b/vm/vm.go
@@ -254,6 +254,25 @@ func equal(lhsV, rhsV reflect.Value) bool {
 	return reflect.DeepEqual(lhsV.Interface(), rhsV.Interface())
 }
 
+// isHashable returns true if the value can be used as a map key without
+// panicking. A nil interface is a valid map key even though
+// reflect.Value.Comparable reports false for it.
+func isHashable(v reflect.Value) bool {
+	if v.Kind() == reflect.Interface && v.IsNil() {
+		return true
+	}
+	return v.Comparable()
+}
+
+// hashableTypeString returns the type string of the value for error messages,
+// unwrapping interfaces to show the dynamic type.
+func hashableTypeString(v reflect.Value) string {
+	if v.Kind() == reflect.Interface && !v.IsNil() {
+		v = v.Elem()
+	}
+	return v.Type().String()
+}
+
 func getMapIndex(key reflect.Value, aMap reflect.Value) reflect.Value {
 	if aMap.IsNil() {
 		return nilValue
@@ -262,6 +281,10 @@ func getMapIndex(key reflect.Value, aMap reflect.Value) reflect.Value {
 	var err error
 	key, err = convertReflectValueToType(key, aMap.Type().Key())
 	if err != nil {
+		return nilValue
+	}
+	if !isHashable(key) {
+		// an unhashable key can never be in a map
 		return nilValue
 	}
 

--- a/vm/vmContainers_test.go
+++ b/vm/vmContainers_test.go
@@ -874,6 +874,14 @@ func TestMaps(t *testing.T) {
 		{Script: `b[1] = 1`, RunError: fmt.Errorf("undefined symbol 'b'")},
 		{Script: `z.y.x = 1`, RunError: fmt.Errorf("undefined symbol 'z'")},
 
+		// unhashable map keys should error instead of panic
+		{Script: `{[1,2]: 3}`, RunError: fmt.Errorf("type []interface {} cannot be used as map key")},
+		{Script: `a = {}; a[[1,2]] = 3`, RunError: fmt.Errorf("type []interface {} cannot be used as map key"), Output: map[string]interface{}{"a": map[interface{}]interface{}{}}},
+		{Script: `a = {}; a[{"x":1}] = 3`, RunError: fmt.Errorf("type map[interface {}]interface {} cannot be used as map key"), Output: map[string]interface{}{"a": map[interface{}]interface{}{}}},
+		{Script: `a = {}; a[[1,2]]`, RunOutput: nil, Output: map[string]interface{}{"a": map[interface{}]interface{}{}}},
+		{Script: `a = {"b": 1}; delete(a, [1,2])`, RunError: fmt.Errorf("type []interface {} cannot be used as map key in delete"), Output: map[string]interface{}{"a": map[interface{}]interface{}{"b": int64(1)}}},
+		{Script: `a = {}; a[nil] = 1; a[nil]`, RunOutput: int64(1)},
+
 		{Script: `{}`, RunOutput: map[interface{}]interface{}{}},
 		{Script: `{"b": nil}`, RunOutput: map[interface{}]interface{}{"b": nil}},
 		{Script: `{"b": true}`, RunOutput: map[interface{}]interface{}{"b": true}},

--- a/vm/vmExpr.go
+++ b/vm/vmExpr.go
@@ -86,6 +86,11 @@ func (runInfo *runInfoStruct) invokeExpr() {
 					return
 				}
 				key = runInfo.rv
+				if !isHashable(key) {
+					runInfo.err = newStringError(expr, "type "+hashableTypeString(key)+" cannot be used as map key")
+					runInfo.rv = nilValue
+					return
+				}
 
 				runInfo.expr = expr.Values[i]
 				runInfo.invokeExpr()
@@ -129,6 +134,11 @@ func (runInfo *runInfoStruct) invokeExpr() {
 			key, runInfo.err = convertReflectValueToType(runInfo.rv, keyType)
 			if runInfo.err != nil {
 				runInfo.err = newStringError(expr, "cannot use type "+key.Type().String()+" as type "+keyType.String()+" as map key")
+				runInfo.rv = nilValue
+				return
+			}
+			if !isHashable(key) {
+				runInfo.err = newStringError(expr, "type "+hashableTypeString(key)+" cannot be used as map key")
 				runInfo.rv = nilValue
 				return
 			}

--- a/vm/vmLetExpr.go
+++ b/vm/vmLetExpr.go
@@ -179,6 +179,11 @@ func (runInfo *runInfoStruct) invokeLetExpr() {
 				runInfo.rv = nilValue
 				return
 			}
+			if !isHashable(runInfo.rv) {
+				runInfo.err = newStringError(expr, "type "+hashableTypeString(runInfo.rv)+" cannot be used as map key")
+				runInfo.rv = nilValue
+				return
+			}
 
 			value, runInfo.err = convertReflectValueToType(value, item.Type().Elem())
 			if runInfo.err != nil {

--- a/vm/vmStmt.go
+++ b/vm/vmStmt.go
@@ -714,6 +714,11 @@ func (runInfo *runInfoStruct) runSingleStmt() {
 				runInfo.rv = nilValue
 				return
 			}
+			if !isHashable(runInfo.rv) {
+				runInfo.err = newStringError(stmt, "type "+hashableTypeString(runInfo.rv)+" cannot be used as map key in delete")
+				runInfo.rv = nilValue
+				return
+			}
 			item.SetMapIndex(runInfo.rv, reflect.Value{})
 			runInfo.rv = nilValue
 		default:


### PR DESCRIPTION
Using a slice or map as a map key crashed the host program with an uncaught reflect panic in four places: map literals, map index assignment, map index read, and delete.

- `{[1,2]: 3}`
- `a = {}; a[[1,2]] = 3`
- `a = {}; a[[1,2]]`
- `delete(m, [1,2])`

Writes and deletes now return a VM error; reads return nil, matching the existing behavior for keys whose type cannot be converted. A nil key remains valid, as in Go.