### PR TITLE
Fix data races with sync package types

### DIFF
--- a/packages/sync.go
+++ b/packages/sync.go
@@ -11,13 +11,15 @@ func init() {
 	env.Packages["sync"] = map[string]reflect.Value{
 		"NewCond": reflect.ValueOf(sync.NewCond),
 	}
+	// sync types contain locks and must not be copied, so they are
+	// defined as pointer types to keep the VM from copying the values
 	env.PackageTypes["sync"] = map[string]reflect.Type{
-		"Cond":      reflect.TypeOf(sync.Cond{}),
-		"Mutex":     reflect.TypeOf(sync.Mutex{}),
-		"Once":      reflect.TypeOf(sync.Once{}),
-		"Pool":      reflect.TypeOf(sync.Pool{}),
-		"RWMutex":   reflect.TypeOf(sync.RWMutex{}),
-		"WaitGroup": reflect.TypeOf(sync.WaitGroup{}),
+		"Cond":      reflect.TypeOf(&sync.Cond{}),
+		"Mutex":     reflect.TypeOf(&sync.Mutex{}),
+		"Once":      reflect.TypeOf(&sync.Once{}),
+		"Pool":      reflect.TypeOf(&sync.Pool{}),
+		"RWMutex":   reflect.TypeOf(&sync.RWMutex{}),
+		"WaitGroup": reflect.TypeOf(&sync.WaitGroup{}),
 	}
 	syncGo19()
 }

--- a/packages/syncGo19.go
+++ b/packages/syncGo19.go
@@ -10,5 +10,5 @@ import (
 )
 
 func syncGo19() {
-	env.PackageTypes["sync"]["Map"] = reflect.TypeOf(sync.Map{})
+	env.PackageTypes["sync"]["Map"] = reflect.TypeOf(&sync.Map{})
 }

--- a/vm/vmExprFunction.go
+++ b/vm/vmExprFunction.go
@@ -83,7 +83,6 @@ func (runInfo *runInfoStruct) anonCallExpr() {
 	anonCallExpr := runInfo.expr.(*ast.AnonCallExpr)
 
 	runInfo.expr = anonCallExpr.Expr
-	runInfo.expr.SetPosition(anonCallExpr.Expr.Position())
 	runInfo.invokeExpr()
 	if runInfo.err != nil {
 		return


### PR DESCRIPTION
Two data races reported in #363, both visible with `go test -race ./vm/` in TestPackagesSync:

- sync package types were registered as value types, so every VM access copied the lock-containing struct through reflect while goroutines mutated it. They are now registered as pointer types (as suggested in the issue), which also fixes the copylocks misuse itself.
- anonCallExpr wrote to the shared AST via a self-assigning SetPosition on every call, racing with concurrent execution of the same AST. The call was a no-op and is removed.

The full test suite now passes under -race.

Fixes #363