### PR TITLE
Widen int64 cache and compare integers without float conversion

### DIFF
--- a/vm/vm.go
+++ b/vm/vm.go
@@ -129,7 +129,7 @@ func isNil(v reflect.Value) bool {
 }
 
 const int64CacheMin = -1
-const int64CacheMax = 256
+const int64CacheMax = 4095
 
 var int64Cache [int64CacheMax - int64CacheMin + 1]reflect.Value
 
@@ -167,6 +167,15 @@ func numToString(v reflect.Value) string {
 	default:
 		return ""
 	}
+}
+
+// isIntKind returns true if the value is a signed integer kind.
+func isIntKind(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return true
+	}
+	return false
 }
 
 func isNum(v reflect.Value) bool {

--- a/vm/vmOperator.go
+++ b/vm/vmOperator.go
@@ -89,25 +89,50 @@ func (runInfo *runInfoStruct) invokeOperator() {
 				runInfo.rv = falseValue
 			}
 		case "<":
-			if toFloat64(lhsV) < toFloat64(runInfo.rv) {
+			// integers are compared as integers to keep full int64 precision
+			var result bool
+			if isIntKind(lhsV) && isIntKind(runInfo.rv) {
+				result = lhsV.Int() < runInfo.rv.Int()
+			} else {
+				result = toFloat64(lhsV) < toFloat64(runInfo.rv)
+			}
+			if result {
 				runInfo.rv = trueValue
 			} else {
 				runInfo.rv = falseValue
 			}
 		case "<=":
-			if toFloat64(lhsV) <= toFloat64(runInfo.rv) {
+			var result bool
+			if isIntKind(lhsV) && isIntKind(runInfo.rv) {
+				result = lhsV.Int() <= runInfo.rv.Int()
+			} else {
+				result = toFloat64(lhsV) <= toFloat64(runInfo.rv)
+			}
+			if result {
 				runInfo.rv = trueValue
 			} else {
 				runInfo.rv = falseValue
 			}
 		case ">":
-			if toFloat64(lhsV) > toFloat64(runInfo.rv) {
+			var result bool
+			if isIntKind(lhsV) && isIntKind(runInfo.rv) {
+				result = lhsV.Int() > runInfo.rv.Int()
+			} else {
+				result = toFloat64(lhsV) > toFloat64(runInfo.rv)
+			}
+			if result {
 				runInfo.rv = trueValue
 			} else {
 				runInfo.rv = falseValue
 			}
 		case ">=":
-			if toFloat64(lhsV) >= toFloat64(runInfo.rv) {
+			var result bool
+			if isIntKind(lhsV) && isIntKind(runInfo.rv) {
+				result = lhsV.Int() >= runInfo.rv.Int()
+			} else {
+				result = toFloat64(lhsV) >= toFloat64(runInfo.rv)
+			}
+			if result {
 				runInfo.rv = trueValue
 			} else {
 				runInfo.rv = falseValue

--- a/vm/vmOperators_test.go
+++ b/vm/vmOperators_test.go
@@ -190,6 +190,12 @@ func TestComparisonOperators(t *testing.T) {
 		{Script: `a == 2`, Input: map[string]interface{}{"a": int64(2)}, RunOutput: true, Output: map[string]interface{}{"a": int64(2)}},
 		{Script: `a != 1`, Input: map[string]interface{}{"a": int64(2)}, RunOutput: true, Output: map[string]interface{}{"a": int64(2)}},
 		{Script: `a != 2`, Input: map[string]interface{}{"a": int64(2)}, RunOutput: false, Output: map[string]interface{}{"a": int64(2)}},
+
+		// int64 comparisons keep full precision beyond float64 (2^53)
+		{Script: `9223372036854775807 > 9223372036854775806`, RunOutput: true},
+		{Script: `9223372036854775806 < 9223372036854775807`, RunOutput: true},
+		{Script: `9223372036854775807 <= 9223372036854775806`, RunOutput: false},
+		{Script: `9223372036854775807 >= 9223372036854775807`, RunOutput: true},
 		{Script: `a == 1.0`, Input: map[string]interface{}{"a": int64(2)}, RunOutput: false, Output: map[string]interface{}{"a": int64(2)}},
 		{Script: `a == 2.0`, Input: map[string]interface{}{"a": int64(2)}, RunOutput: true, Output: map[string]interface{}{"a": int64(2)}},
 		{Script: `a != 1.0`, Input: map[string]interface{}{"a": int64(2)}, RunOutput: true, Output: map[string]interface{}{"a": int64(2)}},


### PR DESCRIPTION
Two changes for arithmetic-heavy scripts:

- The int64 value cache covered -1..256, so loop counters and sums beyond that boxed a new value on every operation. It now covers -1..4095 (~130KB resident).
- The <, <=, >, >= operators converted both sides to float64 even for integer operands. Integers are now compared as int64, which is faster and also fixes wrong results above 2^53 where float64 loses precision (e.g. `9223372036854775807 > 9223372036854775806` returned false).

BenchmarkLoop: 37.2us -> 35.3us, allocations 91 -> 23.