### PR TITLE
Split giant VM type-switch functions into per-node methods

### DIFF
--- a/vm/vmExpr.go
+++ b/vm/vmExpr.go
@@ -29,721 +29,72 @@ func (runInfo *runInfoStruct) invokeExpr() {
 
 	// ArrayExpr
 	case *ast.ArrayExpr:
-		if expr.TypeData == nil {
-			slice := make([]interface{}, len(expr.Exprs))
-			var i int
-			for i, runInfo.expr = range expr.Exprs {
-				runInfo.invokeExpr()
-				if runInfo.err != nil {
-					return
-				}
-				slice[i] = runInfo.rv.Interface()
-			}
-			runInfo.rv = reflect.ValueOf(slice)
-			return
-		}
-
-		t := makeType(runInfo, expr.TypeData)
-		if runInfo.err != nil {
-			runInfo.rv = nilValue
-			return
-		}
-		if t == nil {
-			runInfo.err = newStringError(expr, "cannot make type nil")
-			runInfo.rv = nilValue
-			return
-		}
-
-		slice := reflect.MakeSlice(t, len(expr.Exprs), len(expr.Exprs))
-		var i int
-		valueType := t.Elem()
-		for i, runInfo.expr = range expr.Exprs {
-			runInfo.invokeExpr()
-			if runInfo.err != nil {
-				return
-			}
-
-			runInfo.rv, runInfo.err = convertReflectValueToType(runInfo.rv, valueType)
-			if runInfo.err != nil {
-				runInfo.err = newStringError(expr, "cannot use type "+runInfo.rv.Type().String()+" as type "+valueType.String()+" as slice value")
-				runInfo.rv = nilValue
-				return
-			}
-
-			slice.Index(i).Set(runInfo.rv)
-		}
-		runInfo.rv = slice
+		runInfo.invokeArrayExpr(expr)
 
 	// MapExpr
 	case *ast.MapExpr:
-		if expr.TypeData == nil {
-			var i int
-			var key reflect.Value
-			m := make(map[interface{}]interface{}, len(expr.Keys))
-			for i, runInfo.expr = range expr.Keys {
-				runInfo.invokeExpr()
-				if runInfo.err != nil {
-					return
-				}
-				key = runInfo.rv
-				if !isHashable(key) {
-					runInfo.err = newStringError(expr, "type "+hashableTypeString(key)+" cannot be used as map key")
-					runInfo.rv = nilValue
-					return
-				}
-
-				runInfo.expr = expr.Values[i]
-				runInfo.invokeExpr()
-				if runInfo.err != nil {
-					return
-				}
-
-				m[key.Interface()] = runInfo.rv.Interface()
-			}
-			runInfo.rv = reflect.ValueOf(m)
-			return
-		}
-
-		t := makeType(runInfo, expr.TypeData)
-		if runInfo.err != nil {
-			runInfo.rv = nilValue
-			return
-		}
-		if t == nil {
-			runInfo.err = newStringError(expr, "cannot make type nil")
-			runInfo.rv = nilValue
-			return
-		}
-
-		runInfo.rv, runInfo.err = makeValue(t)
-		if runInfo.err != nil {
-			runInfo.rv = nilValue
-			return
-		}
-
-		var i int
-		var key reflect.Value
-		m := runInfo.rv
-		keyType := t.Key()
-		valueType := t.Elem()
-		for i, runInfo.expr = range expr.Keys {
-			runInfo.invokeExpr()
-			if runInfo.err != nil {
-				return
-			}
-			key, runInfo.err = convertReflectValueToType(runInfo.rv, keyType)
-			if runInfo.err != nil {
-				runInfo.err = newStringError(expr, "cannot use type "+key.Type().String()+" as type "+keyType.String()+" as map key")
-				runInfo.rv = nilValue
-				return
-			}
-			if !isHashable(key) {
-				runInfo.err = newStringError(expr, "type "+hashableTypeString(key)+" cannot be used as map key")
-				runInfo.rv = nilValue
-				return
-			}
-
-			runInfo.expr = expr.Values[i]
-			runInfo.invokeExpr()
-			if runInfo.err != nil {
-				return
-			}
-			runInfo.rv, runInfo.err = convertReflectValueToType(runInfo.rv, valueType)
-			if runInfo.err != nil {
-				runInfo.err = newStringError(expr, "cannot use type "+runInfo.rv.Type().String()+" as type "+valueType.String()+" as map value")
-				runInfo.rv = nilValue
-				return
-			}
-
-			m.SetMapIndex(key, runInfo.rv)
-		}
-		runInfo.rv = m
+		runInfo.invokeMapExpr(expr)
 
 	// DerefExpr
 	case *ast.DerefExpr:
-		runInfo.expr = expr.Expr
-		runInfo.invokeExpr()
-		if runInfo.err != nil {
-			return
-		}
-
-		if runInfo.rv.Kind() != reflect.Ptr {
-			runInfo.err = newStringError(expr.Expr, "cannot deference non-pointer")
-			runInfo.rv = nilValue
-			return
-		}
-		runInfo.rv = runInfo.rv.Elem()
+		runInfo.invokeDerefExpr(expr)
 
 	// AddrExpr
 	case *ast.AddrExpr:
-		runInfo.expr = expr.Expr
-		runInfo.invokeExpr()
-		if runInfo.err != nil {
-			return
-		}
-
-		if runInfo.rv.CanAddr() {
-			runInfo.rv = runInfo.rv.Addr()
-		} else {
-			i := runInfo.rv.Interface()
-			runInfo.rv = reflect.ValueOf(&i)
-		}
+		runInfo.invokeAddrExpr(expr)
 
 	// UnaryExpr
 	case *ast.UnaryExpr:
-		runInfo.expr = expr.Expr
-		runInfo.invokeExpr()
-		if runInfo.err != nil {
-			return
-		}
-
-		switch expr.Operator {
-		case "-":
-			switch runInfo.rv.Kind() {
-			case reflect.Int64:
-				runInfo.rv = int64Value(-runInfo.rv.Int())
-			case reflect.Int32, reflect.Int16, reflect.Int8, reflect.Int, reflect.Bool:
-				runInfo.rv = int64Value(-toInt64(runInfo.rv))
-			case reflect.Float64:
-				runInfo.rv = float64Value(-runInfo.rv.Float())
-			default:
-				runInfo.rv = float64Value(-toFloat64(runInfo.rv))
-			}
-		case "^":
-			runInfo.rv = int64Value(^toInt64(runInfo.rv))
-		case "!":
-			if toBool(runInfo.rv) {
-				runInfo.rv = falseValue
-			} else {
-				runInfo.rv = trueValue
-			}
-		default:
-			runInfo.err = newStringError(expr, "unknown operator")
-			runInfo.rv = nilValue
-		}
+		runInfo.invokeUnaryExpr(expr)
 
 	// ParenExpr
 	case *ast.ParenExpr:
 		runInfo.expr = expr.SubExpr
 		runInfo.invokeExpr()
-		if runInfo.err != nil {
-			return
-		}
 
 	// MemberExpr
 	case *ast.MemberExpr:
-		runInfo.expr = expr.Expr
-		runInfo.invokeExpr()
-		if runInfo.err != nil {
-			return
-		}
-
-		if runInfo.rv.Kind() == reflect.Interface && !runInfo.rv.IsNil() {
-			runInfo.rv = runInfo.rv.Elem()
-		}
-
-		if env, ok := runInfo.rv.Interface().(*env.Env); ok {
-			runInfo.rv, runInfo.err = env.GetValue(expr.Name)
-			if runInfo.err != nil {
-				runInfo.err = newError(expr, runInfo.err)
-				runInfo.rv = nilValue
-			}
-			return
-		}
-
-		value := runInfo.rv.MethodByName(expr.Name)
-		if value.IsValid() {
-			runInfo.rv = value
-			return
-		}
-
-		if runInfo.rv.Kind() == reflect.Ptr {
-			runInfo.rv = runInfo.rv.Elem()
-		}
-
-		switch runInfo.rv.Kind() {
-		case reflect.Struct:
-			field, found := runInfo.rv.Type().FieldByName(expr.Name)
-			if found {
-				runInfo.rv = runInfo.rv.FieldByIndex(field.Index)
-				return
-			}
-			if runInfo.rv.CanAddr() {
-				runInfo.rv = runInfo.rv.Addr()
-				method, found := runInfo.rv.Type().MethodByName(expr.Name)
-				if found {
-					runInfo.rv = runInfo.rv.Method(method.Index)
-					return
-				}
-			} else {
-				// Check wether method with pointer receiver is defined,
-				// if yes, invoke it in the copied instance
-				method, found := reflect.PtrTo(runInfo.rv.Type()).MethodByName(expr.Name)
-				if found {
-					// Create pointer value to given struct type which were passed by value
-					cv := reflect.New(runInfo.rv.Type())
-					cv.Elem().Set(runInfo.rv)
-					runInfo.rv = cv.Method(method.Index)
-					return
-				}
-			}
-			runInfo.err = newStringError(expr, "no member named '"+expr.Name+"' for struct")
-			runInfo.rv = nilValue
-		case reflect.Map:
-			runInfo.rv = getMapIndex(reflect.ValueOf(expr.Name), runInfo.rv)
-		default:
-			runInfo.err = newStringError(expr, "type "+runInfo.rv.Kind().String()+" does not support member operation")
-			runInfo.rv = nilValue
-		}
+		runInfo.invokeMemberExpr(expr)
 
 	// ItemExpr
 	case *ast.ItemExpr:
-		runInfo.expr = expr.Item
-		runInfo.invokeExpr()
-		if runInfo.err != nil {
-			return
-		}
-		item := runInfo.rv
-
-		runInfo.expr = expr.Index
-		runInfo.invokeExpr()
-		if runInfo.err != nil {
-			return
-		}
-
-		if item.Kind() == reflect.Interface && !item.IsNil() {
-			item = item.Elem()
-		}
-
-		switch item.Kind() {
-		case reflect.String, reflect.Slice, reflect.Array:
-			var index int
-			index, runInfo.err = tryToInt(runInfo.rv)
-			if runInfo.err != nil {
-				runInfo.err = newStringError(expr, "index must be a number")
-				runInfo.rv = nilValue
-				return
-			}
-			if index < 0 || index >= item.Len() {
-				runInfo.err = newStringError(expr, "index out of range")
-				runInfo.rv = nilValue
-				return
-			}
-			if item.Kind() != reflect.String {
-				runInfo.rv = item.Index(index)
-			} else {
-				// String
-				runInfo.rv = item.Index(index).Convert(stringType)
-			}
-		case reflect.Map:
-			runInfo.rv = getMapIndex(runInfo.rv, item)
-		default:
-			runInfo.err = newStringError(expr, "type "+item.Kind().String()+" does not support index operation")
-			runInfo.rv = nilValue
-		}
+		runInfo.invokeItemExpr(expr)
 
 	// SliceExpr
 	case *ast.SliceExpr:
-		runInfo.expr = expr.Item
-		runInfo.invokeExpr()
-		if runInfo.err != nil {
-			return
-		}
-		item := runInfo.rv
-
-		if item.Kind() == reflect.Interface && !item.IsNil() {
-			item = item.Elem()
-		}
-
-		switch item.Kind() {
-		case reflect.String, reflect.Slice, reflect.Array:
-			var beginIndex int
-			endIndex := item.Len()
-
-			if expr.Begin != nil {
-				runInfo.expr = expr.Begin
-				runInfo.invokeExpr()
-				if runInfo.err != nil {
-					return
-				}
-				beginIndex, runInfo.err = tryToInt(runInfo.rv)
-				if runInfo.err != nil {
-					runInfo.err = newStringError(expr, "index must be a number")
-					runInfo.rv = nilValue
-					return
-				}
-				// (0 <= low) <= high <= len(a)
-				if beginIndex < 0 {
-					runInfo.err = newStringError(expr, "index out of range")
-					runInfo.rv = nilValue
-					return
-				}
-			}
-
-			if expr.End != nil {
-				runInfo.expr = expr.End
-				runInfo.invokeExpr()
-				if runInfo.err != nil {
-					return
-				}
-				endIndex, runInfo.err = tryToInt(runInfo.rv)
-				if runInfo.err != nil {
-					runInfo.err = newStringError(expr, "index must be a number")
-					runInfo.rv = nilValue
-					return
-				}
-				// 0 <= low <= (high <= len(a))
-				if endIndex > item.Len() {
-					runInfo.err = newStringError(expr, "index out of range")
-					runInfo.rv = nilValue
-					return
-				}
-			}
-
-			// 0 <= (low <= high) <= len(a)
-			if beginIndex > endIndex {
-				runInfo.err = newStringError(expr, "index out of range")
-				runInfo.rv = nilValue
-				return
-			}
-
-			if item.Kind() == reflect.String {
-				if expr.Cap != nil {
-					runInfo.err = newStringError(expr, "type string does not support cap")
-					runInfo.rv = nilValue
-					return
-				}
-				runInfo.rv = item.Slice(beginIndex, endIndex)
-				return
-			}
-
-			sliceCap := item.Cap()
-			if expr.Cap != nil {
-				runInfo.expr = expr.Cap
-				runInfo.invokeExpr()
-				if runInfo.err != nil {
-					return
-				}
-				sliceCap, runInfo.err = tryToInt(runInfo.rv)
-				if runInfo.err != nil {
-					runInfo.err = newStringError(expr, "cap must be a number")
-					runInfo.rv = nilValue
-					return
-				}
-				//  0 <= low <= (high <= max <= cap(a))
-				if sliceCap < endIndex || sliceCap > item.Cap() {
-					runInfo.err = newStringError(expr, "cap out of range")
-					runInfo.rv = nilValue
-					return
-				}
-			}
-
-			runInfo.rv = item.Slice3(beginIndex, endIndex, sliceCap)
-
-		default:
-			runInfo.err = newStringError(expr, "type "+item.Kind().String()+" does not support slice operation")
-			runInfo.rv = nilValue
-		}
+		runInfo.invokeSliceExpr(expr)
 
 	// LetsExpr
 	case *ast.LetsExpr:
-		var i int
-		for i, runInfo.expr = range expr.RHSS {
-			runInfo.invokeExpr()
-			if runInfo.err != nil {
-				return
-			}
-			if runInfo.rv.Kind() == reflect.Interface && !runInfo.rv.IsNil() {
-				runInfo.rv = runInfo.rv.Elem()
-			}
-			if i < len(expr.LHSS) {
-				runInfo.expr = expr.LHSS[i]
-				runInfo.invokeLetExpr()
-				if runInfo.err != nil {
-					return
-				}
-			}
-
-		}
+		runInfo.invokeLetsExpr(expr)
 
 	// TernaryOpExpr
 	case *ast.TernaryOpExpr:
-		runInfo.expr = expr.Expr
-		runInfo.invokeExpr()
-		if runInfo.err != nil {
-			return
-		}
-
-		if toBool(runInfo.rv) {
-			runInfo.expr = expr.LHS
-		} else {
-			runInfo.expr = expr.RHS
-		}
-		runInfo.invokeExpr()
+		runInfo.invokeTernaryOpExpr(expr)
 
 	// NilCoalescingOpExpr
 	case *ast.NilCoalescingOpExpr:
-		// if left side has no error and is not nil, returns left side
-		// otherwise returns right side
-		runInfo.expr = expr.LHS
-		runInfo.invokeExpr()
-		if runInfo.err == nil {
-			if !isNil(runInfo.rv) {
-				return
-			}
-		} else {
-			runInfo.err = nil
-		}
-		runInfo.expr = expr.RHS
-		runInfo.invokeExpr()
+		runInfo.invokeNilCoalescingOpExpr(expr)
 
 	// LenExpr
 	case *ast.LenExpr:
-		runInfo.expr = expr.Expr
-		runInfo.invokeExpr()
-		if runInfo.err != nil {
-			return
-		}
-
-		if runInfo.rv.Kind() == reflect.Interface && !runInfo.rv.IsNil() {
-			runInfo.rv = runInfo.rv.Elem()
-		}
-
-		switch runInfo.rv.Kind() {
-		case reflect.Slice, reflect.Array, reflect.Map, reflect.String, reflect.Chan:
-			runInfo.rv = int64Value(int64(runInfo.rv.Len()))
-		default:
-			runInfo.err = newStringError(expr, "type "+runInfo.rv.Kind().String()+" does not support len operation")
-			runInfo.rv = nilValue
-		}
+		runInfo.invokeLenExpr(expr)
 
 	// ImportExpr
 	case *ast.ImportExpr:
-		runInfo.expr = expr.Name
-		runInfo.invokeExpr()
-		if runInfo.err != nil {
-			return
-		}
-		runInfo.rv, runInfo.err = convertReflectValueToType(runInfo.rv, stringType)
-		if runInfo.err != nil {
-			runInfo.rv = nilValue
-			return
-		}
-		name := runInfo.rv.String()
-		runInfo.rv = nilValue
-
-		methods, ok := env.Packages[name]
-		if !ok {
-			runInfo.err = newStringError(expr, "package not found: "+name)
-			return
-		}
-		var err error
-		pack := runInfo.env.NewEnv()
-		for methodName, methodValue := range methods {
-			err = pack.DefineValue(methodName, methodValue)
-			if err != nil {
-				runInfo.err = newStringError(expr, "import DefineValue error: "+err.Error())
-				return
-			}
-		}
-
-		types, ok := env.PackageTypes[name]
-		if ok {
-			for typeName, typeValue := range types {
-				err = pack.DefineReflectType(typeName, typeValue)
-				if err != nil {
-					runInfo.err = newStringError(expr, "import DefineReflectType error: "+err.Error())
-					return
-				}
-			}
-		}
-
-		runInfo.rv = reflect.ValueOf(pack)
+		runInfo.invokeImportExpr(expr)
 
 	// MakeExpr
 	case *ast.MakeExpr:
-		t := makeType(runInfo, expr.TypeData)
-		if runInfo.err != nil {
-			runInfo.rv = nilValue
-			return
-		}
-		if t == nil {
-			runInfo.err = newStringError(expr, "cannot make type nil")
-			runInfo.rv = nilValue
-			return
-		}
-
-		switch expr.TypeData.Kind {
-		case ast.TypeSlice:
-			aLen := 0
-			if expr.LenExpr != nil {
-				runInfo.expr = expr.LenExpr
-				runInfo.invokeExpr()
-				if runInfo.err != nil {
-					return
-				}
-				aLen = toInt(runInfo.rv)
-			}
-			cap := aLen
-			if expr.CapExpr != nil {
-				runInfo.expr = expr.CapExpr
-				runInfo.invokeExpr()
-				if runInfo.err != nil {
-					return
-				}
-				cap = toInt(runInfo.rv)
-			}
-			if aLen < 0 {
-				runInfo.err = newStringError(expr, "make slice len must not be negative")
-				runInfo.rv = nilValue
-				return
-			}
-			if cap < 0 {
-				runInfo.err = newStringError(expr, "make slice cap must not be negative")
-				runInfo.rv = nilValue
-				return
-			}
-			if aLen > cap {
-				runInfo.err = newStringError(expr, "make slice len > cap")
-				runInfo.rv = nilValue
-				return
-			}
-			runInfo.rv = reflect.MakeSlice(t, aLen, cap)
-			return
-		case ast.TypeChan:
-			aLen := 0
-			if expr.LenExpr != nil {
-				runInfo.expr = expr.LenExpr
-				runInfo.invokeExpr()
-				if runInfo.err != nil {
-					return
-				}
-				aLen = toInt(runInfo.rv)
-			}
-			if aLen < 0 {
-				runInfo.err = newStringError(expr, "make chan buffer size must not be negative")
-				runInfo.rv = nilValue
-				return
-			}
-			runInfo.rv = reflect.MakeChan(t, aLen)
-			return
-		}
-
-		runInfo.rv, runInfo.err = makeValue(t)
+		runInfo.invokeMakeExpr(expr)
 
 	// MakeTypeExpr
 	case *ast.MakeTypeExpr:
-		runInfo.expr = expr.Type
-		runInfo.invokeExpr()
-		if runInfo.err != nil {
-			return
-		}
-
-		// if expr.Name has a dot in it, it should give a syntax error, so no needs to check err
-		runInfo.env.DefineReflectType(expr.Name, runInfo.rv.Type())
-
-		runInfo.rv = reflect.ValueOf(runInfo.rv.Type())
+		runInfo.invokeMakeTypeExpr(expr)
 
 	// ChanExpr
 	case *ast.ChanExpr:
-		runInfo.expr = expr.RHS
-		runInfo.invokeExpr()
-		if runInfo.err != nil {
-			return
-		}
-		if runInfo.rv.Kind() == reflect.Interface && !runInfo.rv.IsNil() {
-			runInfo.rv = runInfo.rv.Elem()
-		}
-
-		var lhs reflect.Value
-		rhs := runInfo.rv
-
-		if expr.LHS == nil {
-			// lhs is nil
-			if rhs.Kind() != reflect.Chan {
-				// rhs is not channel
-				runInfo.err = newStringError(expr, "receive from non-chan type "+rhs.Kind().String())
-				runInfo.rv = nilValue
-				return
-			}
-		} else {
-			// lhs is not nil
-			runInfo.expr = expr.LHS
-			runInfo.invokeExpr()
-			if runInfo.err != nil {
-				return
-			}
-			if runInfo.rv.Kind() == reflect.Interface && !runInfo.rv.IsNil() {
-				runInfo.rv = runInfo.rv.Elem()
-			}
-			if runInfo.rv.Kind() != reflect.Chan {
-				// lhs is not channel
-				// lhs <- chan rhs or lhs <- rhs
-				runInfo.err = newStringError(expr, "send to non-chan type "+runInfo.rv.Kind().String())
-				runInfo.rv = nilValue
-				return
-			}
-			lhs = runInfo.rv
-		}
-
-		var chosen int
-		var ok bool
-
-		if rhs.Kind() == reflect.Chan {
-			// rhs is channel
-			// receive from rhs channel
-			cases := []reflect.SelectCase{{
-				Dir:  reflect.SelectRecv,
-				Chan: reflect.ValueOf(runInfo.ctx.Done()),
-			}, {
-				Dir:  reflect.SelectRecv,
-				Chan: rhs,
-			}}
-			chosen, runInfo.rv, ok = reflect.Select(cases)
-			if chosen == 0 {
-				runInfo.err = ErrInterrupt
-				runInfo.rv = nilValue
-				return
-			}
-			if !ok {
-				runInfo.rv = nilValue
-				return
-			}
-			rhs = runInfo.rv
-		}
-
-		if expr.LHS == nil {
-			// <- chan rhs is receive
-			return
-		}
-
-		// chan lhs <- chan rhs is receive & send
-		// or
-		// chan lhs <- rhs is send
-
-		runInfo.rv = nilValue
-		rhs, runInfo.err = convertReflectValueToType(rhs, lhs.Type().Elem())
-		if runInfo.err != nil {
-			runInfo.err = newStringError(expr, "cannot use type "+rhs.Type().String()+" as type "+lhs.Type().Elem().String()+" to send to chan")
-			return
-		}
-		// send rhs to lhs channel
-		cases := []reflect.SelectCase{{
-			Dir:  reflect.SelectRecv,
-			Chan: reflect.ValueOf(runInfo.ctx.Done()),
-		}, {
-			Dir:  reflect.SelectSend,
-			Chan: lhs,
-			Send: rhs,
-		}}
-		if !runInfo.options.Debug {
-			// captures panic
-			defer recoverFunc(runInfo)
-		}
-		chosen, _, _ = reflect.Select(cases)
-		if chosen == 0 {
-			runInfo.err = ErrInterrupt
-		}
+		runInfo.invokeChanExpr(expr)
 
 	// FuncExpr
 	case *ast.FuncExpr:
@@ -762,36 +113,767 @@ func (runInfo *runInfoStruct) invokeExpr() {
 
 	// IncludeExpr
 	case *ast.IncludeExpr:
-		runInfo.expr = expr.ItemExpr
-		runInfo.invokeExpr()
-		if runInfo.err != nil {
-			return
-		}
-		itemExpr := runInfo.rv
-
-		runInfo.expr = expr.ListExpr
-		runInfo.invokeExpr()
-		if runInfo.err != nil {
-			return
-		}
-
-		if runInfo.rv.Kind() != reflect.Slice && runInfo.rv.Kind() != reflect.Array {
-			runInfo.err = newStringError(expr, "second argument must be slice or array; but have "+runInfo.rv.Kind().String())
-			runInfo.rv = nilValue
-			return
-		}
-
-		for i := 0; i < runInfo.rv.Len(); i++ {
-			if equal(itemExpr, runInfo.rv.Index(i)) {
-				runInfo.rv = trueValue
-				return
-			}
-		}
-		runInfo.rv = falseValue
+		runInfo.invokeIncludeExpr(expr)
 
 	default:
 		runInfo.err = newStringError(expr, "unknown expression")
 		runInfo.rv = nilValue
 	}
 
+}
+
+// invokeArrayExpr evaluates an array expression.
+func (runInfo *runInfoStruct) invokeArrayExpr(expr *ast.ArrayExpr) {
+	if expr.TypeData == nil {
+		slice := make([]interface{}, len(expr.Exprs))
+		var i int
+		for i, runInfo.expr = range expr.Exprs {
+			runInfo.invokeExpr()
+			if runInfo.err != nil {
+				return
+			}
+			slice[i] = runInfo.rv.Interface()
+		}
+		runInfo.rv = reflect.ValueOf(slice)
+		return
+	}
+
+	t := makeType(runInfo, expr.TypeData)
+	if runInfo.err != nil {
+		runInfo.rv = nilValue
+		return
+	}
+	if t == nil {
+		runInfo.err = newStringError(expr, "cannot make type nil")
+		runInfo.rv = nilValue
+		return
+	}
+
+	slice := reflect.MakeSlice(t, len(expr.Exprs), len(expr.Exprs))
+	var i int
+	valueType := t.Elem()
+	for i, runInfo.expr = range expr.Exprs {
+		runInfo.invokeExpr()
+		if runInfo.err != nil {
+			return
+		}
+
+		runInfo.rv, runInfo.err = convertReflectValueToType(runInfo.rv, valueType)
+		if runInfo.err != nil {
+			runInfo.err = newStringError(expr, "cannot use type "+runInfo.rv.Type().String()+" as type "+valueType.String()+" as slice value")
+			runInfo.rv = nilValue
+			return
+		}
+
+		slice.Index(i).Set(runInfo.rv)
+	}
+	runInfo.rv = slice
+}
+
+// invokeMapExpr evaluates a map expression.
+func (runInfo *runInfoStruct) invokeMapExpr(expr *ast.MapExpr) {
+	if expr.TypeData == nil {
+		var i int
+		var key reflect.Value
+		m := make(map[interface{}]interface{}, len(expr.Keys))
+		for i, runInfo.expr = range expr.Keys {
+			runInfo.invokeExpr()
+			if runInfo.err != nil {
+				return
+			}
+			key = runInfo.rv
+			if !isHashable(key) {
+				runInfo.err = newStringError(expr, "type "+hashableTypeString(key)+" cannot be used as map key")
+				runInfo.rv = nilValue
+				return
+			}
+
+			runInfo.expr = expr.Values[i]
+			runInfo.invokeExpr()
+			if runInfo.err != nil {
+				return
+			}
+
+			m[key.Interface()] = runInfo.rv.Interface()
+		}
+		runInfo.rv = reflect.ValueOf(m)
+		return
+	}
+
+	t := makeType(runInfo, expr.TypeData)
+	if runInfo.err != nil {
+		runInfo.rv = nilValue
+		return
+	}
+	if t == nil {
+		runInfo.err = newStringError(expr, "cannot make type nil")
+		runInfo.rv = nilValue
+		return
+	}
+
+	runInfo.rv, runInfo.err = makeValue(t)
+	if runInfo.err != nil {
+		runInfo.rv = nilValue
+		return
+	}
+
+	var i int
+	var key reflect.Value
+	m := runInfo.rv
+	keyType := t.Key()
+	valueType := t.Elem()
+	for i, runInfo.expr = range expr.Keys {
+		runInfo.invokeExpr()
+		if runInfo.err != nil {
+			return
+		}
+		key, runInfo.err = convertReflectValueToType(runInfo.rv, keyType)
+		if runInfo.err != nil {
+			runInfo.err = newStringError(expr, "cannot use type "+key.Type().String()+" as type "+keyType.String()+" as map key")
+			runInfo.rv = nilValue
+			return
+		}
+		if !isHashable(key) {
+			runInfo.err = newStringError(expr, "type "+hashableTypeString(key)+" cannot be used as map key")
+			runInfo.rv = nilValue
+			return
+		}
+
+		runInfo.expr = expr.Values[i]
+		runInfo.invokeExpr()
+		if runInfo.err != nil {
+			return
+		}
+		runInfo.rv, runInfo.err = convertReflectValueToType(runInfo.rv, valueType)
+		if runInfo.err != nil {
+			runInfo.err = newStringError(expr, "cannot use type "+runInfo.rv.Type().String()+" as type "+valueType.String()+" as map value")
+			runInfo.rv = nilValue
+			return
+		}
+
+		m.SetMapIndex(key, runInfo.rv)
+	}
+	runInfo.rv = m
+}
+
+// invokeDerefExpr evaluates a dereference expression.
+func (runInfo *runInfoStruct) invokeDerefExpr(expr *ast.DerefExpr) {
+	runInfo.expr = expr.Expr
+	runInfo.invokeExpr()
+	if runInfo.err != nil {
+		return
+	}
+
+	if runInfo.rv.Kind() != reflect.Ptr {
+		runInfo.err = newStringError(expr.Expr, "cannot deference non-pointer")
+		runInfo.rv = nilValue
+		return
+	}
+	runInfo.rv = runInfo.rv.Elem()
+}
+
+// invokeAddrExpr evaluates an address expression.
+func (runInfo *runInfoStruct) invokeAddrExpr(expr *ast.AddrExpr) {
+	runInfo.expr = expr.Expr
+	runInfo.invokeExpr()
+	if runInfo.err != nil {
+		return
+	}
+
+	if runInfo.rv.CanAddr() {
+		runInfo.rv = runInfo.rv.Addr()
+	} else {
+		i := runInfo.rv.Interface()
+		runInfo.rv = reflect.ValueOf(&i)
+	}
+}
+
+// invokeUnaryExpr evaluates a unary expression.
+func (runInfo *runInfoStruct) invokeUnaryExpr(expr *ast.UnaryExpr) {
+	runInfo.expr = expr.Expr
+	runInfo.invokeExpr()
+	if runInfo.err != nil {
+		return
+	}
+
+	switch expr.Operator {
+	case "-":
+		switch runInfo.rv.Kind() {
+		case reflect.Int64:
+			runInfo.rv = int64Value(-runInfo.rv.Int())
+		case reflect.Int32, reflect.Int16, reflect.Int8, reflect.Int, reflect.Bool:
+			runInfo.rv = int64Value(-toInt64(runInfo.rv))
+		case reflect.Float64:
+			runInfo.rv = float64Value(-runInfo.rv.Float())
+		default:
+			runInfo.rv = float64Value(-toFloat64(runInfo.rv))
+		}
+	case "^":
+		runInfo.rv = int64Value(^toInt64(runInfo.rv))
+	case "!":
+		if toBool(runInfo.rv) {
+			runInfo.rv = falseValue
+		} else {
+			runInfo.rv = trueValue
+		}
+	default:
+		runInfo.err = newStringError(expr, "unknown operator")
+		runInfo.rv = nilValue
+	}
+}
+
+// invokeMemberExpr evaluates a member expression.
+func (runInfo *runInfoStruct) invokeMemberExpr(expr *ast.MemberExpr) {
+	runInfo.expr = expr.Expr
+	runInfo.invokeExpr()
+	if runInfo.err != nil {
+		return
+	}
+
+	if runInfo.rv.Kind() == reflect.Interface && !runInfo.rv.IsNil() {
+		runInfo.rv = runInfo.rv.Elem()
+	}
+
+	if env, ok := runInfo.rv.Interface().(*env.Env); ok {
+		runInfo.rv, runInfo.err = env.GetValue(expr.Name)
+		if runInfo.err != nil {
+			runInfo.err = newError(expr, runInfo.err)
+			runInfo.rv = nilValue
+		}
+		return
+	}
+
+	value := runInfo.rv.MethodByName(expr.Name)
+	if value.IsValid() {
+		runInfo.rv = value
+		return
+	}
+
+	if runInfo.rv.Kind() == reflect.Ptr {
+		runInfo.rv = runInfo.rv.Elem()
+	}
+
+	switch runInfo.rv.Kind() {
+	case reflect.Struct:
+		field, found := runInfo.rv.Type().FieldByName(expr.Name)
+		if found {
+			runInfo.rv = runInfo.rv.FieldByIndex(field.Index)
+			return
+		}
+		if runInfo.rv.CanAddr() {
+			runInfo.rv = runInfo.rv.Addr()
+			method, found := runInfo.rv.Type().MethodByName(expr.Name)
+			if found {
+				runInfo.rv = runInfo.rv.Method(method.Index)
+				return
+			}
+		} else {
+			// Check wether method with pointer receiver is defined,
+			// if yes, invoke it in the copied instance
+			method, found := reflect.PtrTo(runInfo.rv.Type()).MethodByName(expr.Name)
+			if found {
+				// Create pointer value to given struct type which were passed by value
+				cv := reflect.New(runInfo.rv.Type())
+				cv.Elem().Set(runInfo.rv)
+				runInfo.rv = cv.Method(method.Index)
+				return
+			}
+		}
+		runInfo.err = newStringError(expr, "no member named '"+expr.Name+"' for struct")
+		runInfo.rv = nilValue
+	case reflect.Map:
+		runInfo.rv = getMapIndex(reflect.ValueOf(expr.Name), runInfo.rv)
+	default:
+		runInfo.err = newStringError(expr, "type "+runInfo.rv.Kind().String()+" does not support member operation")
+		runInfo.rv = nilValue
+	}
+}
+
+// invokeItemExpr evaluates an index expression.
+func (runInfo *runInfoStruct) invokeItemExpr(expr *ast.ItemExpr) {
+	runInfo.expr = expr.Item
+	runInfo.invokeExpr()
+	if runInfo.err != nil {
+		return
+	}
+	item := runInfo.rv
+
+	runInfo.expr = expr.Index
+	runInfo.invokeExpr()
+	if runInfo.err != nil {
+		return
+	}
+
+	if item.Kind() == reflect.Interface && !item.IsNil() {
+		item = item.Elem()
+	}
+
+	switch item.Kind() {
+	case reflect.String, reflect.Slice, reflect.Array:
+		var index int
+		index, runInfo.err = tryToInt(runInfo.rv)
+		if runInfo.err != nil {
+			runInfo.err = newStringError(expr, "index must be a number")
+			runInfo.rv = nilValue
+			return
+		}
+		if index < 0 || index >= item.Len() {
+			runInfo.err = newStringError(expr, "index out of range")
+			runInfo.rv = nilValue
+			return
+		}
+		if item.Kind() != reflect.String {
+			runInfo.rv = item.Index(index)
+		} else {
+			// String
+			runInfo.rv = item.Index(index).Convert(stringType)
+		}
+	case reflect.Map:
+		runInfo.rv = getMapIndex(runInfo.rv, item)
+	default:
+		runInfo.err = newStringError(expr, "type "+item.Kind().String()+" does not support index operation")
+		runInfo.rv = nilValue
+	}
+}
+
+// invokeSliceExpr evaluates a slice expression.
+func (runInfo *runInfoStruct) invokeSliceExpr(expr *ast.SliceExpr) {
+	runInfo.expr = expr.Item
+	runInfo.invokeExpr()
+	if runInfo.err != nil {
+		return
+	}
+	item := runInfo.rv
+
+	if item.Kind() == reflect.Interface && !item.IsNil() {
+		item = item.Elem()
+	}
+
+	switch item.Kind() {
+	case reflect.String, reflect.Slice, reflect.Array:
+		var beginIndex int
+		endIndex := item.Len()
+
+		if expr.Begin != nil {
+			runInfo.expr = expr.Begin
+			runInfo.invokeExpr()
+			if runInfo.err != nil {
+				return
+			}
+			beginIndex, runInfo.err = tryToInt(runInfo.rv)
+			if runInfo.err != nil {
+				runInfo.err = newStringError(expr, "index must be a number")
+				runInfo.rv = nilValue
+				return
+			}
+			// (0 <= low) <= high <= len(a)
+			if beginIndex < 0 {
+				runInfo.err = newStringError(expr, "index out of range")
+				runInfo.rv = nilValue
+				return
+			}
+		}
+
+		if expr.End != nil {
+			runInfo.expr = expr.End
+			runInfo.invokeExpr()
+			if runInfo.err != nil {
+				return
+			}
+			endIndex, runInfo.err = tryToInt(runInfo.rv)
+			if runInfo.err != nil {
+				runInfo.err = newStringError(expr, "index must be a number")
+				runInfo.rv = nilValue
+				return
+			}
+			// 0 <= low <= (high <= len(a))
+			if endIndex > item.Len() {
+				runInfo.err = newStringError(expr, "index out of range")
+				runInfo.rv = nilValue
+				return
+			}
+		}
+
+		// 0 <= (low <= high) <= len(a)
+		if beginIndex > endIndex {
+			runInfo.err = newStringError(expr, "index out of range")
+			runInfo.rv = nilValue
+			return
+		}
+
+		if item.Kind() == reflect.String {
+			if expr.Cap != nil {
+				runInfo.err = newStringError(expr, "type string does not support cap")
+				runInfo.rv = nilValue
+				return
+			}
+			runInfo.rv = item.Slice(beginIndex, endIndex)
+			return
+		}
+
+		sliceCap := item.Cap()
+		if expr.Cap != nil {
+			runInfo.expr = expr.Cap
+			runInfo.invokeExpr()
+			if runInfo.err != nil {
+				return
+			}
+			sliceCap, runInfo.err = tryToInt(runInfo.rv)
+			if runInfo.err != nil {
+				runInfo.err = newStringError(expr, "cap must be a number")
+				runInfo.rv = nilValue
+				return
+			}
+			//  0 <= low <= (high <= max <= cap(a))
+			if sliceCap < endIndex || sliceCap > item.Cap() {
+				runInfo.err = newStringError(expr, "cap out of range")
+				runInfo.rv = nilValue
+				return
+			}
+		}
+
+		runInfo.rv = item.Slice3(beginIndex, endIndex, sliceCap)
+
+	default:
+		runInfo.err = newStringError(expr, "type "+item.Kind().String()+" does not support slice operation")
+		runInfo.rv = nilValue
+	}
+}
+
+// invokeLetsExpr evaluates a lets expression.
+func (runInfo *runInfoStruct) invokeLetsExpr(expr *ast.LetsExpr) {
+	var i int
+	for i, runInfo.expr = range expr.RHSS {
+		runInfo.invokeExpr()
+		if runInfo.err != nil {
+			return
+		}
+		if runInfo.rv.Kind() == reflect.Interface && !runInfo.rv.IsNil() {
+			runInfo.rv = runInfo.rv.Elem()
+		}
+		if i < len(expr.LHSS) {
+			runInfo.expr = expr.LHSS[i]
+			runInfo.invokeLetExpr()
+			if runInfo.err != nil {
+				return
+			}
+		}
+
+	}
+}
+
+// invokeTernaryOpExpr evaluates a ternary operator expression.
+func (runInfo *runInfoStruct) invokeTernaryOpExpr(expr *ast.TernaryOpExpr) {
+	runInfo.expr = expr.Expr
+	runInfo.invokeExpr()
+	if runInfo.err != nil {
+		return
+	}
+
+	if toBool(runInfo.rv) {
+		runInfo.expr = expr.LHS
+	} else {
+		runInfo.expr = expr.RHS
+	}
+	runInfo.invokeExpr()
+}
+
+// invokeNilCoalescingOpExpr evaluates a nil coalescing operator expression.
+func (runInfo *runInfoStruct) invokeNilCoalescingOpExpr(expr *ast.NilCoalescingOpExpr) {
+	// if left side has no error and is not nil, returns left side
+	// otherwise returns right side
+	runInfo.expr = expr.LHS
+	runInfo.invokeExpr()
+	if runInfo.err == nil {
+		if !isNil(runInfo.rv) {
+			return
+		}
+	} else {
+		runInfo.err = nil
+	}
+	runInfo.expr = expr.RHS
+	runInfo.invokeExpr()
+}
+
+// invokeLenExpr evaluates a len expression.
+func (runInfo *runInfoStruct) invokeLenExpr(expr *ast.LenExpr) {
+	runInfo.expr = expr.Expr
+	runInfo.invokeExpr()
+	if runInfo.err != nil {
+		return
+	}
+
+	if runInfo.rv.Kind() == reflect.Interface && !runInfo.rv.IsNil() {
+		runInfo.rv = runInfo.rv.Elem()
+	}
+
+	switch runInfo.rv.Kind() {
+	case reflect.Slice, reflect.Array, reflect.Map, reflect.String, reflect.Chan:
+		runInfo.rv = int64Value(int64(runInfo.rv.Len()))
+	default:
+		runInfo.err = newStringError(expr, "type "+runInfo.rv.Kind().String()+" does not support len operation")
+		runInfo.rv = nilValue
+	}
+}
+
+// invokeImportExpr evaluates an import expression.
+func (runInfo *runInfoStruct) invokeImportExpr(expr *ast.ImportExpr) {
+	runInfo.expr = expr.Name
+	runInfo.invokeExpr()
+	if runInfo.err != nil {
+		return
+	}
+	runInfo.rv, runInfo.err = convertReflectValueToType(runInfo.rv, stringType)
+	if runInfo.err != nil {
+		runInfo.rv = nilValue
+		return
+	}
+	name := runInfo.rv.String()
+	runInfo.rv = nilValue
+
+	methods, ok := env.Packages[name]
+	if !ok {
+		runInfo.err = newStringError(expr, "package not found: "+name)
+		return
+	}
+	var err error
+	pack := runInfo.env.NewEnv()
+	for methodName, methodValue := range methods {
+		err = pack.DefineValue(methodName, methodValue)
+		if err != nil {
+			runInfo.err = newStringError(expr, "import DefineValue error: "+err.Error())
+			return
+		}
+	}
+
+	types, ok := env.PackageTypes[name]
+	if ok {
+		for typeName, typeValue := range types {
+			err = pack.DefineReflectType(typeName, typeValue)
+			if err != nil {
+				runInfo.err = newStringError(expr, "import DefineReflectType error: "+err.Error())
+				return
+			}
+		}
+	}
+
+	runInfo.rv = reflect.ValueOf(pack)
+}
+
+// invokeMakeExpr evaluates a make expression.
+func (runInfo *runInfoStruct) invokeMakeExpr(expr *ast.MakeExpr) {
+	t := makeType(runInfo, expr.TypeData)
+	if runInfo.err != nil {
+		runInfo.rv = nilValue
+		return
+	}
+	if t == nil {
+		runInfo.err = newStringError(expr, "cannot make type nil")
+		runInfo.rv = nilValue
+		return
+	}
+
+	switch expr.TypeData.Kind {
+	case ast.TypeSlice:
+		aLen := 0
+		if expr.LenExpr != nil {
+			runInfo.expr = expr.LenExpr
+			runInfo.invokeExpr()
+			if runInfo.err != nil {
+				return
+			}
+			aLen = toInt(runInfo.rv)
+		}
+		cap := aLen
+		if expr.CapExpr != nil {
+			runInfo.expr = expr.CapExpr
+			runInfo.invokeExpr()
+			if runInfo.err != nil {
+				return
+			}
+			cap = toInt(runInfo.rv)
+		}
+		if aLen < 0 {
+			runInfo.err = newStringError(expr, "make slice len must not be negative")
+			runInfo.rv = nilValue
+			return
+		}
+		if cap < 0 {
+			runInfo.err = newStringError(expr, "make slice cap must not be negative")
+			runInfo.rv = nilValue
+			return
+		}
+		if aLen > cap {
+			runInfo.err = newStringError(expr, "make slice len > cap")
+			runInfo.rv = nilValue
+			return
+		}
+		runInfo.rv = reflect.MakeSlice(t, aLen, cap)
+		return
+	case ast.TypeChan:
+		aLen := 0
+		if expr.LenExpr != nil {
+			runInfo.expr = expr.LenExpr
+			runInfo.invokeExpr()
+			if runInfo.err != nil {
+				return
+			}
+			aLen = toInt(runInfo.rv)
+		}
+		if aLen < 0 {
+			runInfo.err = newStringError(expr, "make chan buffer size must not be negative")
+			runInfo.rv = nilValue
+			return
+		}
+		runInfo.rv = reflect.MakeChan(t, aLen)
+		return
+	}
+
+	runInfo.rv, runInfo.err = makeValue(t)
+}
+
+// invokeMakeTypeExpr evaluates a make type expression.
+func (runInfo *runInfoStruct) invokeMakeTypeExpr(expr *ast.MakeTypeExpr) {
+	runInfo.expr = expr.Type
+	runInfo.invokeExpr()
+	if runInfo.err != nil {
+		return
+	}
+
+	// if expr.Name has a dot in it, it should give a syntax error, so no needs to check err
+	runInfo.env.DefineReflectType(expr.Name, runInfo.rv.Type())
+
+	runInfo.rv = reflect.ValueOf(runInfo.rv.Type())
+}
+
+// invokeChanExpr evaluates a channel expression.
+func (runInfo *runInfoStruct) invokeChanExpr(expr *ast.ChanExpr) {
+	runInfo.expr = expr.RHS
+	runInfo.invokeExpr()
+	if runInfo.err != nil {
+		return
+	}
+	if runInfo.rv.Kind() == reflect.Interface && !runInfo.rv.IsNil() {
+		runInfo.rv = runInfo.rv.Elem()
+	}
+
+	var lhs reflect.Value
+	rhs := runInfo.rv
+
+	if expr.LHS == nil {
+		// lhs is nil
+		if rhs.Kind() != reflect.Chan {
+			// rhs is not channel
+			runInfo.err = newStringError(expr, "receive from non-chan type "+rhs.Kind().String())
+			runInfo.rv = nilValue
+			return
+		}
+	} else {
+		// lhs is not nil
+		runInfo.expr = expr.LHS
+		runInfo.invokeExpr()
+		if runInfo.err != nil {
+			return
+		}
+		if runInfo.rv.Kind() == reflect.Interface && !runInfo.rv.IsNil() {
+			runInfo.rv = runInfo.rv.Elem()
+		}
+		if runInfo.rv.Kind() != reflect.Chan {
+			// lhs is not channel
+			// lhs <- chan rhs or lhs <- rhs
+			runInfo.err = newStringError(expr, "send to non-chan type "+runInfo.rv.Kind().String())
+			runInfo.rv = nilValue
+			return
+		}
+		lhs = runInfo.rv
+	}
+
+	var chosen int
+	var ok bool
+
+	if rhs.Kind() == reflect.Chan {
+		// rhs is channel
+		// receive from rhs channel
+		cases := []reflect.SelectCase{{
+			Dir:  reflect.SelectRecv,
+			Chan: reflect.ValueOf(runInfo.ctx.Done()),
+		}, {
+			Dir:  reflect.SelectRecv,
+			Chan: rhs,
+		}}
+		chosen, runInfo.rv, ok = reflect.Select(cases)
+		if chosen == 0 {
+			runInfo.err = ErrInterrupt
+			runInfo.rv = nilValue
+			return
+		}
+		if !ok {
+			runInfo.rv = nilValue
+			return
+		}
+		rhs = runInfo.rv
+	}
+
+	if expr.LHS == nil {
+		// <- chan rhs is receive
+		return
+	}
+
+	// chan lhs <- chan rhs is receive & send
+	// or
+	// chan lhs <- rhs is send
+
+	runInfo.rv = nilValue
+	rhs, runInfo.err = convertReflectValueToType(rhs, lhs.Type().Elem())
+	if runInfo.err != nil {
+		runInfo.err = newStringError(expr, "cannot use type "+rhs.Type().String()+" as type "+lhs.Type().Elem().String()+" to send to chan")
+		return
+	}
+	// send rhs to lhs channel
+	cases := []reflect.SelectCase{{
+		Dir:  reflect.SelectRecv,
+		Chan: reflect.ValueOf(runInfo.ctx.Done()),
+	}, {
+		Dir:  reflect.SelectSend,
+		Chan: lhs,
+		Send: rhs,
+	}}
+	if !runInfo.options.Debug {
+		// captures panic
+		defer recoverFunc(runInfo)
+	}
+	chosen, _, _ = reflect.Select(cases)
+	if chosen == 0 {
+		runInfo.err = ErrInterrupt
+	}
+}
+
+// invokeIncludeExpr evaluates an include expression.
+func (runInfo *runInfoStruct) invokeIncludeExpr(expr *ast.IncludeExpr) {
+	runInfo.expr = expr.ItemExpr
+	runInfo.invokeExpr()
+	if runInfo.err != nil {
+		return
+	}
+	itemExpr := runInfo.rv
+
+	runInfo.expr = expr.ListExpr
+	runInfo.invokeExpr()
+	if runInfo.err != nil {
+		return
+	}
+
+	if runInfo.rv.Kind() != reflect.Slice && runInfo.rv.Kind() != reflect.Array {
+		runInfo.err = newStringError(expr, "second argument must be slice or array; but have "+runInfo.rv.Kind().String())
+		runInfo.rv = nilValue
+		return
+	}
+
+	for i := 0; i < runInfo.rv.Len(); i++ {
+		if equal(itemExpr, runInfo.rv.Index(i)) {
+			runInfo.rv = trueValue
+			return
+		}
+	}
+	runInfo.rv = falseValue
 }

--- a/vm/vmLetExpr.go
+++ b/vm/vmLetExpr.go
@@ -7,6 +7,7 @@ import (
 	"github.com/mattn/anko/env"
 )
 
+// invokeLetExpr assigns runInfo.rv to the given expression.
 func (runInfo *runInfoStruct) invokeLetExpr() {
 	switch expr := runInfo.expr.(type) {
 
@@ -19,369 +20,407 @@ func (runInfo *runInfoStruct) invokeLetExpr() {
 
 	// MemberExpr
 	case *ast.MemberExpr:
-		value := runInfo.rv
-
-		runInfo.expr = expr.Expr
-		runInfo.invokeExpr()
-		if runInfo.err != nil {
-			return
-		}
-
-		if runInfo.rv.Kind() == reflect.Interface && !runInfo.rv.IsNil() {
-			runInfo.rv = runInfo.rv.Elem()
-		}
-
-		if env, ok := runInfo.rv.Interface().(*env.Env); ok {
-			runInfo.err = env.SetValue(expr.Name, value)
-			if runInfo.err != nil {
-				runInfo.err = newError(expr, runInfo.err)
-				runInfo.rv = nilValue
-			}
-			return
-		}
-
-		if runInfo.rv.Kind() == reflect.Ptr {
-			runInfo.rv = runInfo.rv.Elem()
-		}
-
-		switch runInfo.rv.Kind() {
-
-		// Struct
-		case reflect.Struct:
-			field, found := runInfo.rv.Type().FieldByName(expr.Name)
-			if !found {
-				runInfo.err = newStringError(expr, "no member named '"+expr.Name+"' for struct")
-				runInfo.rv = nilValue
-				return
-			}
-			runInfo.rv = runInfo.rv.FieldByIndex(field.Index)
-			// From reflect CanSet:
-			// A Value can be changed only if it is addressable and was not obtained by the use of unexported struct fields.
-			// Often a struct has to be passed as a pointer to be set
-			if !runInfo.rv.CanSet() {
-				runInfo.err = newStringError(expr, "struct member '"+expr.Name+"' cannot be assigned")
-				runInfo.rv = nilValue
-				return
-			}
-
-			value, runInfo.err = convertReflectValueToType(value, runInfo.rv.Type())
-			if runInfo.err != nil {
-				runInfo.err = newStringError(expr, "type "+value.Type().String()+" cannot be assigned to type "+runInfo.rv.Type().String()+" for struct")
-				runInfo.rv = nilValue
-				return
-			}
-
-			runInfo.rv.Set(value)
-			return
-
-		// Map
-		case reflect.Map:
-			value, runInfo.err = convertReflectValueToType(value, runInfo.rv.Type().Elem())
-			if runInfo.err != nil {
-				runInfo.err = newStringError(expr, "type "+value.Type().String()+" cannot be assigned to type "+runInfo.rv.Type().Elem().String()+" for map")
-				runInfo.rv = nilValue
-				return
-			}
-			if runInfo.rv.IsNil() {
-				// make new map
-				item := reflect.MakeMap(runInfo.rv.Type())
-				item.SetMapIndex(reflect.ValueOf(expr.Name), value)
-				// assign new map
-				runInfo.rv = item
-				runInfo.expr = expr.Expr
-				runInfo.invokeLetExpr()
-				runInfo.rv = item.MapIndex(reflect.ValueOf(expr.Name))
-				return
-			}
-			runInfo.rv.SetMapIndex(reflect.ValueOf(expr.Name), value)
-
-		default:
-			runInfo.err = newStringError(expr, "type "+runInfo.rv.Kind().String()+" does not support member operation")
-			runInfo.rv = nilValue
-		}
+		runInfo.invokeLetMemberExpr(expr)
 
 	// ItemExpr
 	case *ast.ItemExpr:
-		value := runInfo.rv
-
-		runInfo.expr = expr.Item
-		runInfo.invokeExpr()
-		if runInfo.err != nil {
-			return
-		}
-		item := runInfo.rv
-
-		runInfo.expr = expr.Index
-		runInfo.invokeExpr()
-		if runInfo.err != nil {
-			return
-		}
-
-		if item.Kind() == reflect.Interface && !item.IsNil() {
-			item = item.Elem()
-		}
-
-		switch item.Kind() {
-
-		// Slice && Array
-		case reflect.Slice, reflect.Array:
-			var index int
-			index, runInfo.err = tryToInt(runInfo.rv)
-			if runInfo.err != nil {
-				runInfo.err = newStringError(expr, "index must be a number")
-				runInfo.rv = nilValue
-				return
-			}
-
-			if index == item.Len() {
-				// try to do automatic append
-				value, runInfo.err = convertReflectValueToType(value, item.Type().Elem())
-				if runInfo.err != nil {
-					runInfo.err = newStringError(expr, "type "+value.Type().String()+" cannot be assigned to type "+item.Type().Elem().String()+" for slice index")
-					runInfo.rv = nilValue
-					return
-				}
-				item = reflect.Append(item, value)
-				runInfo.rv = item
-				runInfo.expr = expr.Item
-				runInfo.invokeLetExpr()
-				runInfo.rv = item.Index(index)
-				return
-			}
-
-			if index < 0 || index >= item.Len() {
-				runInfo.err = newStringError(expr, "index out of range")
-				runInfo.rv = nilValue
-				return
-			}
-			item = item.Index(index)
-			if !item.CanSet() {
-				runInfo.err = newStringError(expr, "index cannot be assigned")
-				runInfo.rv = nilValue
-				return
-			}
-
-			value, runInfo.err = convertReflectValueToType(value, item.Type())
-			if runInfo.err != nil {
-				runInfo.err = newStringError(expr, "type "+value.Type().String()+" cannot be assigned to type "+item.Type().String()+" for slice index")
-				runInfo.rv = nilValue
-				return
-			}
-
-			item.Set(value)
-			runInfo.rv = item
-
-		// Map
-		case reflect.Map:
-			runInfo.rv, runInfo.err = convertReflectValueToType(runInfo.rv, item.Type().Key())
-			if runInfo.err != nil {
-				runInfo.err = newStringError(expr, "index type "+runInfo.rv.Type().String()+" cannot be used for map index type "+item.Type().Key().String())
-				runInfo.rv = nilValue
-				return
-			}
-			if !isHashable(runInfo.rv) {
-				runInfo.err = newStringError(expr, "type "+hashableTypeString(runInfo.rv)+" cannot be used as map key")
-				runInfo.rv = nilValue
-				return
-			}
-
-			value, runInfo.err = convertReflectValueToType(value, item.Type().Elem())
-			if runInfo.err != nil {
-				runInfo.err = newStringError(expr, "type "+value.Type().String()+" cannot be assigned to type "+item.Type().Elem().String()+" for map")
-				runInfo.rv = nilValue
-				return
-			}
-
-			if item.IsNil() {
-				// make new map
-				item = reflect.MakeMap(item.Type())
-				item.SetMapIndex(runInfo.rv, value)
-				mapIndex := runInfo.rv
-				// assign new map
-				runInfo.rv = item
-				runInfo.expr = expr.Item
-				runInfo.invokeLetExpr()
-				runInfo.rv = item.MapIndex(mapIndex)
-				return
-			}
-			item.SetMapIndex(runInfo.rv, value)
-
-		// String
-		case reflect.String:
-			var index int
-			index, runInfo.err = tryToInt(runInfo.rv)
-			if runInfo.err != nil {
-				runInfo.err = newStringError(expr, "index must be a number")
-				runInfo.rv = nilValue
-				return
-			}
-
-			value, runInfo.err = convertReflectValueToType(value, item.Type())
-			if runInfo.err != nil {
-				runInfo.err = newStringError(expr, "type "+value.Type().String()+" cannot be assigned to type "+item.Type().String())
-				runInfo.rv = nilValue
-				return
-			}
-
-			if index == item.Len() {
-				// automatic append
-				if item.CanSet() {
-					item.SetString(item.String() + value.String())
-					return
-				}
-
-				runInfo.rv = reflect.ValueOf(item.String() + value.String())
-				runInfo.expr = expr.Item
-				runInfo.invokeLetExpr()
-				return
-			}
-
-			if index < 0 || index >= item.Len() {
-				runInfo.err = newStringError(expr, "index out of range")
-				runInfo.rv = nilValue
-				return
-			}
-
-			if item.CanSet() {
-				item.SetString(item.Slice(0, index).String() + value.String() + item.Slice(index+1, item.Len()).String())
-				runInfo.rv = item
-				return
-			}
-
-			runInfo.rv = reflect.ValueOf(item.Slice(0, index).String() + value.String() + item.Slice(index+1, item.Len()).String())
-			runInfo.expr = expr.Item
-			runInfo.invokeLetExpr()
-
-		default:
-			runInfo.err = newStringError(expr, "type "+item.Kind().String()+" does not support index operation")
-			runInfo.rv = nilValue
-		}
+		runInfo.invokeLetItemExpr(expr)
 
 	// SliceExpr
 	case *ast.SliceExpr:
-		value := runInfo.rv
-
-		runInfo.expr = expr.Item
-		runInfo.invokeExpr()
-		if runInfo.err != nil {
-			return
-		}
-		item := runInfo.rv
-
-		if item.Kind() == reflect.Interface && !item.IsNil() {
-			item = item.Elem()
-		}
-
-		switch item.Kind() {
-
-		// Slice && Array
-		case reflect.Slice, reflect.Array:
-			var beginIndex int
-			endIndex := item.Len()
-
-			if expr.Begin != nil {
-				runInfo.expr = expr.Begin
-				runInfo.invokeExpr()
-				if runInfo.err != nil {
-					return
-				}
-				beginIndex, runInfo.err = tryToInt(runInfo.rv)
-				if runInfo.err != nil {
-					runInfo.err = newStringError(expr, "index must be a number")
-					runInfo.rv = nilValue
-					return
-				}
-				// (0 <= low) <= high <= len(a)
-				if beginIndex < 0 {
-					runInfo.err = newStringError(expr, "index out of range")
-					runInfo.rv = nilValue
-					return
-				}
-			}
-
-			if expr.End != nil {
-				runInfo.expr = expr.End
-				runInfo.invokeExpr()
-				if runInfo.err != nil {
-					return
-				}
-				endIndex, runInfo.err = tryToInt(runInfo.rv)
-				if runInfo.err != nil {
-					runInfo.err = newStringError(expr, "index must be a number")
-					runInfo.rv = nilValue
-					return
-				}
-				// 0 <= low <= (high <= len(a))
-				if endIndex > item.Len() {
-					runInfo.err = newStringError(expr, "index out of range")
-					runInfo.rv = nilValue
-					return
-				}
-			}
-
-			// 0 <= (low <= high) <= len(a)
-			if beginIndex > endIndex {
-				runInfo.err = newStringError(expr, "index out of range")
-				runInfo.rv = nilValue
-				return
-			}
-
-			sliceCap := item.Cap()
-			if expr.Cap != nil {
-				runInfo.expr = expr.Cap
-				runInfo.invokeExpr()
-				if runInfo.err != nil {
-					return
-				}
-				sliceCap, runInfo.err = tryToInt(runInfo.rv)
-				if runInfo.err != nil {
-					runInfo.err = newStringError(expr, "cap must be a number")
-					runInfo.rv = nilValue
-					return
-				}
-				//  0 <= low <= (high <= max <= cap(a))
-				if sliceCap < endIndex || sliceCap > item.Cap() {
-					runInfo.err = newStringError(expr, "cap out of range")
-					runInfo.rv = nilValue
-					return
-				}
-			}
-
-			item = item.Slice3(beginIndex, endIndex, sliceCap)
-
-			if !item.CanSet() {
-				runInfo.err = newStringError(expr, "slice cannot be assigned")
-				runInfo.rv = nilValue
-				return
-			}
-			item.Set(value)
-
-		// String
-		case reflect.String:
-			runInfo.err = newStringError(expr, "type string does not support slice operation for assignment")
-			runInfo.rv = nilValue
-
-		default:
-			runInfo.err = newStringError(expr, "type "+item.Kind().String()+" does not support slice operation")
-			runInfo.rv = nilValue
-		}
+		runInfo.invokeLetSliceExpr(expr)
 
 	// DerefExpr
 	case *ast.DerefExpr:
-		value := runInfo.rv
-
-		runInfo.expr = expr.Expr
-		runInfo.invokeExpr()
-		if runInfo.err != nil {
-			return
-		}
-
-		runInfo.rv.Elem().Set(value)
-		runInfo.rv = value
+		runInfo.invokeLetDerefExpr(expr)
 
 	default:
 		runInfo.err = newStringError(expr, "invalid operation")
 		runInfo.rv = nilValue
 	}
 
+}
+
+// invokeLetMemberExpr assigns a value to a member expression.
+func (runInfo *runInfoStruct) invokeLetMemberExpr(expr *ast.MemberExpr) {
+	value := runInfo.rv
+
+	runInfo.expr = expr.Expr
+	runInfo.invokeExpr()
+	if runInfo.err != nil {
+		return
+	}
+
+	if runInfo.rv.Kind() == reflect.Interface && !runInfo.rv.IsNil() {
+		runInfo.rv = runInfo.rv.Elem()
+	}
+
+	if env, ok := runInfo.rv.Interface().(*env.Env); ok {
+		runInfo.err = env.SetValue(expr.Name, value)
+		if runInfo.err != nil {
+			runInfo.err = newError(expr, runInfo.err)
+			runInfo.rv = nilValue
+		}
+		return
+	}
+
+	if runInfo.rv.Kind() == reflect.Ptr {
+		runInfo.rv = runInfo.rv.Elem()
+	}
+
+	switch runInfo.rv.Kind() {
+
+	// Struct
+	case reflect.Struct:
+		field, found := runInfo.rv.Type().FieldByName(expr.Name)
+		if !found {
+			runInfo.err = newStringError(expr, "no member named '"+expr.Name+"' for struct")
+			runInfo.rv = nilValue
+			return
+		}
+		runInfo.rv = runInfo.rv.FieldByIndex(field.Index)
+		// From reflect CanSet:
+		// A Value can be changed only if it is addressable and was not obtained by the use of unexported struct fields.
+		// Often a struct has to be passed as a pointer to be set
+		if !runInfo.rv.CanSet() {
+			runInfo.err = newStringError(expr, "struct member '"+expr.Name+"' cannot be assigned")
+			runInfo.rv = nilValue
+			return
+		}
+
+		value, runInfo.err = convertReflectValueToType(value, runInfo.rv.Type())
+		if runInfo.err != nil {
+			runInfo.err = newStringError(expr, "type "+value.Type().String()+" cannot be assigned to type "+runInfo.rv.Type().String()+" for struct")
+			runInfo.rv = nilValue
+			return
+		}
+
+		runInfo.rv.Set(value)
+		return
+
+	// Map
+	case reflect.Map:
+		value, runInfo.err = convertReflectValueToType(value, runInfo.rv.Type().Elem())
+		if runInfo.err != nil {
+			runInfo.err = newStringError(expr, "type "+value.Type().String()+" cannot be assigned to type "+runInfo.rv.Type().Elem().String()+" for map")
+			runInfo.rv = nilValue
+			return
+		}
+		if runInfo.rv.IsNil() {
+			// make new map
+			item := reflect.MakeMap(runInfo.rv.Type())
+			item.SetMapIndex(reflect.ValueOf(expr.Name), value)
+			// assign new map
+			runInfo.rv = item
+			runInfo.expr = expr.Expr
+			runInfo.invokeLetExpr()
+			runInfo.rv = item.MapIndex(reflect.ValueOf(expr.Name))
+			return
+		}
+		runInfo.rv.SetMapIndex(reflect.ValueOf(expr.Name), value)
+
+	default:
+		runInfo.err = newStringError(expr, "type "+runInfo.rv.Kind().String()+" does not support member operation")
+		runInfo.rv = nilValue
+	}
+}
+
+// invokeLetItemExpr assigns a value to an index expression.
+func (runInfo *runInfoStruct) invokeLetItemExpr(expr *ast.ItemExpr) {
+	value := runInfo.rv
+
+	runInfo.expr = expr.Item
+	runInfo.invokeExpr()
+	if runInfo.err != nil {
+		return
+	}
+	item := runInfo.rv
+
+	runInfo.expr = expr.Index
+	runInfo.invokeExpr()
+	if runInfo.err != nil {
+		return
+	}
+
+	if item.Kind() == reflect.Interface && !item.IsNil() {
+		item = item.Elem()
+	}
+
+	switch item.Kind() {
+
+	// Slice && Array
+	case reflect.Slice, reflect.Array:
+		runInfo.invokeLetItemSlice(expr, item, value)
+
+	// Map
+	case reflect.Map:
+		runInfo.invokeLetItemMap(expr, item, value)
+
+	// String
+	case reflect.String:
+		runInfo.invokeLetItemString(expr, item, value)
+
+	default:
+		runInfo.err = newStringError(expr, "type "+item.Kind().String()+" does not support index operation")
+		runInfo.rv = nilValue
+	}
+}
+
+// invokeLetItemSlice assigns a value to a slice or array index.
+// runInfo.rv must hold the index value.
+func (runInfo *runInfoStruct) invokeLetItemSlice(expr *ast.ItemExpr, item reflect.Value, value reflect.Value) {
+	var index int
+	index, runInfo.err = tryToInt(runInfo.rv)
+	if runInfo.err != nil {
+		runInfo.err = newStringError(expr, "index must be a number")
+		runInfo.rv = nilValue
+		return
+	}
+
+	if index == item.Len() {
+		// try to do automatic append
+		value, runInfo.err = convertReflectValueToType(value, item.Type().Elem())
+		if runInfo.err != nil {
+			runInfo.err = newStringError(expr, "type "+value.Type().String()+" cannot be assigned to type "+item.Type().Elem().String()+" for slice index")
+			runInfo.rv = nilValue
+			return
+		}
+		item = reflect.Append(item, value)
+		runInfo.rv = item
+		runInfo.expr = expr.Item
+		runInfo.invokeLetExpr()
+		runInfo.rv = item.Index(index)
+		return
+	}
+
+	if index < 0 || index >= item.Len() {
+		runInfo.err = newStringError(expr, "index out of range")
+		runInfo.rv = nilValue
+		return
+	}
+	item = item.Index(index)
+	if !item.CanSet() {
+		runInfo.err = newStringError(expr, "index cannot be assigned")
+		runInfo.rv = nilValue
+		return
+	}
+
+	value, runInfo.err = convertReflectValueToType(value, item.Type())
+	if runInfo.err != nil {
+		runInfo.err = newStringError(expr, "type "+value.Type().String()+" cannot be assigned to type "+item.Type().String()+" for slice index")
+		runInfo.rv = nilValue
+		return
+	}
+
+	item.Set(value)
+	runInfo.rv = item
+}
+
+// invokeLetItemMap assigns a value to a map index.
+// runInfo.rv must hold the index value.
+func (runInfo *runInfoStruct) invokeLetItemMap(expr *ast.ItemExpr, item reflect.Value, value reflect.Value) {
+	runInfo.rv, runInfo.err = convertReflectValueToType(runInfo.rv, item.Type().Key())
+	if runInfo.err != nil {
+		runInfo.err = newStringError(expr, "index type "+runInfo.rv.Type().String()+" cannot be used for map index type "+item.Type().Key().String())
+		runInfo.rv = nilValue
+		return
+	}
+	if !isHashable(runInfo.rv) {
+		runInfo.err = newStringError(expr, "type "+hashableTypeString(runInfo.rv)+" cannot be used as map key")
+		runInfo.rv = nilValue
+		return
+	}
+
+	value, runInfo.err = convertReflectValueToType(value, item.Type().Elem())
+	if runInfo.err != nil {
+		runInfo.err = newStringError(expr, "type "+value.Type().String()+" cannot be assigned to type "+item.Type().Elem().String()+" for map")
+		runInfo.rv = nilValue
+		return
+	}
+
+	if item.IsNil() {
+		// make new map
+		item = reflect.MakeMap(item.Type())
+		item.SetMapIndex(runInfo.rv, value)
+		mapIndex := runInfo.rv
+		// assign new map
+		runInfo.rv = item
+		runInfo.expr = expr.Item
+		runInfo.invokeLetExpr()
+		runInfo.rv = item.MapIndex(mapIndex)
+		return
+	}
+	item.SetMapIndex(runInfo.rv, value)
+}
+
+// invokeLetItemString assigns a value to a string index.
+// runInfo.rv must hold the index value.
+func (runInfo *runInfoStruct) invokeLetItemString(expr *ast.ItemExpr, item reflect.Value, value reflect.Value) {
+	var index int
+	index, runInfo.err = tryToInt(runInfo.rv)
+	if runInfo.err != nil {
+		runInfo.err = newStringError(expr, "index must be a number")
+		runInfo.rv = nilValue
+		return
+	}
+
+	value, runInfo.err = convertReflectValueToType(value, item.Type())
+	if runInfo.err != nil {
+		runInfo.err = newStringError(expr, "type "+value.Type().String()+" cannot be assigned to type "+item.Type().String())
+		runInfo.rv = nilValue
+		return
+	}
+
+	if index == item.Len() {
+		// automatic append
+		if item.CanSet() {
+			item.SetString(item.String() + value.String())
+			return
+		}
+
+		runInfo.rv = reflect.ValueOf(item.String() + value.String())
+		runInfo.expr = expr.Item
+		runInfo.invokeLetExpr()
+		return
+	}
+
+	if index < 0 || index >= item.Len() {
+		runInfo.err = newStringError(expr, "index out of range")
+		runInfo.rv = nilValue
+		return
+	}
+
+	if item.CanSet() {
+		item.SetString(item.Slice(0, index).String() + value.String() + item.Slice(index+1, item.Len()).String())
+		runInfo.rv = item
+		return
+	}
+
+	runInfo.rv = reflect.ValueOf(item.Slice(0, index).String() + value.String() + item.Slice(index+1, item.Len()).String())
+	runInfo.expr = expr.Item
+	runInfo.invokeLetExpr()
+}
+
+// invokeLetSliceExpr assigns a value to a slice expression.
+func (runInfo *runInfoStruct) invokeLetSliceExpr(expr *ast.SliceExpr) {
+	value := runInfo.rv
+
+	runInfo.expr = expr.Item
+	runInfo.invokeExpr()
+	if runInfo.err != nil {
+		return
+	}
+	item := runInfo.rv
+
+	if item.Kind() == reflect.Interface && !item.IsNil() {
+		item = item.Elem()
+	}
+
+	switch item.Kind() {
+
+	// Slice && Array
+	case reflect.Slice, reflect.Array:
+		var beginIndex int
+		endIndex := item.Len()
+
+		if expr.Begin != nil {
+			runInfo.expr = expr.Begin
+			runInfo.invokeExpr()
+			if runInfo.err != nil {
+				return
+			}
+			beginIndex, runInfo.err = tryToInt(runInfo.rv)
+			if runInfo.err != nil {
+				runInfo.err = newStringError(expr, "index must be a number")
+				runInfo.rv = nilValue
+				return
+			}
+			// (0 <= low) <= high <= len(a)
+			if beginIndex < 0 {
+				runInfo.err = newStringError(expr, "index out of range")
+				runInfo.rv = nilValue
+				return
+			}
+		}
+
+		if expr.End != nil {
+			runInfo.expr = expr.End
+			runInfo.invokeExpr()
+			if runInfo.err != nil {
+				return
+			}
+			endIndex, runInfo.err = tryToInt(runInfo.rv)
+			if runInfo.err != nil {
+				runInfo.err = newStringError(expr, "index must be a number")
+				runInfo.rv = nilValue
+				return
+			}
+			// 0 <= low <= (high <= len(a))
+			if endIndex > item.Len() {
+				runInfo.err = newStringError(expr, "index out of range")
+				runInfo.rv = nilValue
+				return
+			}
+		}
+
+		// 0 <= (low <= high) <= len(a)
+		if beginIndex > endIndex {
+			runInfo.err = newStringError(expr, "index out of range")
+			runInfo.rv = nilValue
+			return
+		}
+
+		sliceCap := item.Cap()
+		if expr.Cap != nil {
+			runInfo.expr = expr.Cap
+			runInfo.invokeExpr()
+			if runInfo.err != nil {
+				return
+			}
+			sliceCap, runInfo.err = tryToInt(runInfo.rv)
+			if runInfo.err != nil {
+				runInfo.err = newStringError(expr, "cap must be a number")
+				runInfo.rv = nilValue
+				return
+			}
+			//  0 <= low <= (high <= max <= cap(a))
+			if sliceCap < endIndex || sliceCap > item.Cap() {
+				runInfo.err = newStringError(expr, "cap out of range")
+				runInfo.rv = nilValue
+				return
+			}
+		}
+
+		item = item.Slice3(beginIndex, endIndex, sliceCap)
+
+		if !item.CanSet() {
+			runInfo.err = newStringError(expr, "slice cannot be assigned")
+			runInfo.rv = nilValue
+			return
+		}
+		item.Set(value)
+
+	// String
+	case reflect.String:
+		runInfo.err = newStringError(expr, "type string does not support slice operation for assignment")
+		runInfo.rv = nilValue
+
+	default:
+		runInfo.err = newStringError(expr, "type "+item.Kind().String()+" does not support slice operation")
+		runInfo.rv = nilValue
+	}
+}
+
+// invokeLetDerefExpr assigns a value to a dereference expression.
+func (runInfo *runInfoStruct) invokeLetDerefExpr(expr *ast.DerefExpr) {
+	value := runInfo.rv
+
+	runInfo.expr = expr.Expr
+	runInfo.invokeExpr()
+	if runInfo.err != nil {
+		return
+	}
+
+	runInfo.rv.Elem().Set(value)
+	runInfo.rv = value
 }

--- a/vm/vmOperator.go
+++ b/vm/vmOperator.go
@@ -13,277 +13,273 @@ func (runInfo *runInfoStruct) invokeOperator() {
 
 	// BinaryOperator
 	case *ast.BinaryOperator:
-		runInfo.expr = operator.LHS
-		runInfo.invokeExpr()
-		if runInfo.err != nil {
-			return
-		}
-		if runInfo.rv.Kind() == reflect.Interface && !runInfo.rv.IsNil() {
-			runInfo.rv = runInfo.rv.Elem()
-		}
-
-		switch operator.Operator {
-		case "||":
-			if toBool(runInfo.rv) {
-				runInfo.rv = trueValue
-				return
-			}
-		case "&&":
-			if !toBool(runInfo.rv) {
-				runInfo.rv = falseValue
-				return
-			}
-		default:
-			runInfo.err = newStringError(operator, "unknown operator")
-			runInfo.rv = nilValue
-			return
-		}
-
-		runInfo.expr = operator.RHS
-		runInfo.invokeExpr()
-		if runInfo.err != nil {
-			return
-		}
-		if runInfo.rv.Kind() == reflect.Interface && !runInfo.rv.IsNil() {
-			runInfo.rv = runInfo.rv.Elem()
-		}
-
-		if toBool(runInfo.rv) {
-			runInfo.rv = trueValue
-		} else {
-			runInfo.rv = falseValue
-		}
+		runInfo.invokeBinaryOperator(operator)
 
 	// ComparisonOperator
 	case *ast.ComparisonOperator:
-		runInfo.expr = operator.LHS
-		runInfo.invokeExpr()
-		if runInfo.err != nil {
-			return
-		}
-		if runInfo.rv.Kind() == reflect.Interface && !runInfo.rv.IsNil() {
-			runInfo.rv = runInfo.rv.Elem()
-		}
-		lhsV := runInfo.rv
-
-		runInfo.expr = operator.RHS
-		runInfo.invokeExpr()
-		if runInfo.err != nil {
-			return
-		}
-		if runInfo.rv.Kind() == reflect.Interface && !runInfo.rv.IsNil() {
-			runInfo.rv = runInfo.rv.Elem()
-		}
-
-		switch operator.Operator {
-		case "==":
-			if equal(lhsV, runInfo.rv) {
-				runInfo.rv = trueValue
-			} else {
-				runInfo.rv = falseValue
-			}
-		case "!=":
-			if !equal(lhsV, runInfo.rv) {
-				runInfo.rv = trueValue
-			} else {
-				runInfo.rv = falseValue
-			}
-		case "<":
-			// integers are compared as integers to keep full int64 precision
-			var result bool
-			if isIntKind(lhsV) && isIntKind(runInfo.rv) {
-				result = lhsV.Int() < runInfo.rv.Int()
-			} else {
-				result = toFloat64(lhsV) < toFloat64(runInfo.rv)
-			}
-			if result {
-				runInfo.rv = trueValue
-			} else {
-				runInfo.rv = falseValue
-			}
-		case "<=":
-			var result bool
-			if isIntKind(lhsV) && isIntKind(runInfo.rv) {
-				result = lhsV.Int() <= runInfo.rv.Int()
-			} else {
-				result = toFloat64(lhsV) <= toFloat64(runInfo.rv)
-			}
-			if result {
-				runInfo.rv = trueValue
-			} else {
-				runInfo.rv = falseValue
-			}
-		case ">":
-			var result bool
-			if isIntKind(lhsV) && isIntKind(runInfo.rv) {
-				result = lhsV.Int() > runInfo.rv.Int()
-			} else {
-				result = toFloat64(lhsV) > toFloat64(runInfo.rv)
-			}
-			if result {
-				runInfo.rv = trueValue
-			} else {
-				runInfo.rv = falseValue
-			}
-		case ">=":
-			var result bool
-			if isIntKind(lhsV) && isIntKind(runInfo.rv) {
-				result = lhsV.Int() >= runInfo.rv.Int()
-			} else {
-				result = toFloat64(lhsV) >= toFloat64(runInfo.rv)
-			}
-			if result {
-				runInfo.rv = trueValue
-			} else {
-				runInfo.rv = falseValue
-			}
-		default:
-			runInfo.err = newStringError(operator, "unknown operator")
-			runInfo.rv = nilValue
-		}
+		runInfo.invokeComparisonOperator(operator)
 
 	// AddOperator
 	case *ast.AddOperator:
-		runInfo.expr = operator.LHS
-		runInfo.invokeExpr()
-		if runInfo.err != nil {
-			return
-		}
-		if runInfo.rv.Kind() == reflect.Interface && !runInfo.rv.IsNil() {
-			runInfo.rv = runInfo.rv.Elem()
-		}
-		lhsV := runInfo.rv
-
-		runInfo.expr = operator.RHS
-		runInfo.invokeExpr()
-		if runInfo.err != nil {
-			return
-		}
-		if runInfo.rv.Kind() == reflect.Interface && !runInfo.rv.IsNil() {
-			runInfo.rv = runInfo.rv.Elem()
-		}
-
-		switch operator.Operator {
-		case "+":
-			lhsKind := lhsV.Kind()
-			rhsKind := runInfo.rv.Kind()
-
-			if lhsKind == reflect.Slice || lhsKind == reflect.Array {
-				if rhsKind == reflect.Slice || rhsKind == reflect.Array {
-					// append slice to slice
-					runInfo.rv, runInfo.err = appendSlice(operator, lhsV, runInfo.rv)
-					return
-				}
-				// try to append rhs non-slice to lhs slice
-				runInfo.rv, runInfo.err = convertReflectValueToType(runInfo.rv, lhsV.Type().Elem())
-				if runInfo.err != nil {
-					runInfo.err = newStringError(operator, "invalid type conversion")
-					runInfo.rv = nilValue
-					return
-				}
-				runInfo.rv = reflect.Append(lhsV, runInfo.rv)
-				return
-			}
-			if rhsKind == reflect.Slice || rhsKind == reflect.Array {
-				// can not append rhs slice to lhs non-slice
-				runInfo.err = newStringError(operator, "invalid type conversion")
-				runInfo.rv = nilValue
-				return
-			}
-
-			kind := precedenceOfKinds(lhsKind, rhsKind)
-			switch kind {
-			case reflect.String:
-				runInfo.rv = reflect.ValueOf(toString(lhsV) + toString(runInfo.rv))
-			case reflect.Float64, reflect.Float32:
-				runInfo.rv = float64Value(toFloat64(lhsV) + toFloat64(runInfo.rv))
-			default:
-				runInfo.rv = int64Value(toInt64(lhsV) + toInt64(runInfo.rv))
-			}
-
-		case "-":
-			switch lhsV.Kind() {
-			case reflect.Float64, reflect.Float32:
-				runInfo.rv = float64Value(toFloat64(lhsV) - toFloat64(runInfo.rv))
-				return
-			}
-			switch runInfo.rv.Kind() {
-			case reflect.Float64, reflect.Float32:
-				runInfo.rv = float64Value(toFloat64(lhsV) - toFloat64(runInfo.rv))
-			default:
-				runInfo.rv = int64Value(toInt64(lhsV) - toInt64(runInfo.rv))
-			}
-
-		case "|":
-			runInfo.rv = int64Value(toInt64(lhsV) | toInt64(runInfo.rv))
-		default:
-			runInfo.err = newStringError(operator, "unknown operator")
-			runInfo.rv = nilValue
-		}
+		runInfo.invokeAddOperator(operator)
 
 	// MultiplyOperator
 	case *ast.MultiplyOperator:
-		runInfo.expr = operator.LHS
-		runInfo.invokeExpr()
-		if runInfo.err != nil {
-			return
-		}
-		if runInfo.rv.Kind() == reflect.Interface && !runInfo.rv.IsNil() {
-			runInfo.rv = runInfo.rv.Elem()
-		}
-		lhsV := runInfo.rv
-
-		runInfo.expr = operator.RHS
-		runInfo.invokeExpr()
-		if runInfo.err != nil {
-			return
-		}
-		if runInfo.rv.Kind() == reflect.Interface && !runInfo.rv.IsNil() {
-			runInfo.rv = runInfo.rv.Elem()
-		}
-
-		switch operator.Operator {
-		case "*":
-			if lhsV.Kind() == reflect.String && (runInfo.rv.Kind() == reflect.Int || runInfo.rv.Kind() == reflect.Int32 || runInfo.rv.Kind() == reflect.Int64) {
-				count := toInt64(runInfo.rv)
-				if count < 0 {
-					runInfo.err = newStringError(operator, "negative repeat count")
-					runInfo.rv = nilValue
-					return
-				}
-				runInfo.rv = reflect.ValueOf(strings.Repeat(toString(lhsV), int(count)))
-				return
-			}
-			if lhsV.Kind() == reflect.Float64 || runInfo.rv.Kind() == reflect.Float64 {
-				runInfo.rv = float64Value(toFloat64(lhsV) * toFloat64(runInfo.rv))
-				return
-			}
-			runInfo.rv = int64Value(toInt64(lhsV) * toInt64(runInfo.rv))
-		case "/":
-			runInfo.rv = float64Value(toFloat64(lhsV) / toFloat64(runInfo.rv))
-		case "%":
-			rhs := toInt64(runInfo.rv)
-			if rhs == 0 {
-				runInfo.err = newStringError(operator, "integer divide by zero")
-				runInfo.rv = nilValue
-				return
-			}
-			runInfo.rv = int64Value(toInt64(lhsV) % rhs)
-		case ">>":
-			runInfo.rv = int64Value(toInt64(lhsV) >> uint64(toInt64(runInfo.rv)))
-		case "<<":
-			runInfo.rv = int64Value(toInt64(lhsV) << uint64(toInt64(runInfo.rv)))
-		case "&":
-			runInfo.rv = int64Value(toInt64(lhsV) & toInt64(runInfo.rv))
-
-		default:
-			runInfo.err = newStringError(operator, "unknown operator")
-			runInfo.rv = nilValue
-		}
+		runInfo.invokeMultiplyOperator(operator)
 
 	default:
 		runInfo.err = newStringError(operator, "unknown operator")
 		runInfo.rv = nilValue
 
+	}
+}
+
+// invokeBinaryOperator evaluates a logical and/or operator.
+func (runInfo *runInfoStruct) invokeBinaryOperator(operator *ast.BinaryOperator) {
+	runInfo.expr = operator.LHS
+	runInfo.invokeExpr()
+	if runInfo.err != nil {
+		return
+	}
+	if runInfo.rv.Kind() == reflect.Interface && !runInfo.rv.IsNil() {
+		runInfo.rv = runInfo.rv.Elem()
+	}
+
+	switch operator.Operator {
+	case "||":
+		if toBool(runInfo.rv) {
+			runInfo.rv = trueValue
+			return
+		}
+	case "&&":
+		if !toBool(runInfo.rv) {
+			runInfo.rv = falseValue
+			return
+		}
+	default:
+		runInfo.err = newStringError(operator, "unknown operator")
+		runInfo.rv = nilValue
+		return
+	}
+
+	runInfo.expr = operator.RHS
+	runInfo.invokeExpr()
+	if runInfo.err != nil {
+		return
+	}
+	if runInfo.rv.Kind() == reflect.Interface && !runInfo.rv.IsNil() {
+		runInfo.rv = runInfo.rv.Elem()
+	}
+
+	if toBool(runInfo.rv) {
+		runInfo.rv = trueValue
+	} else {
+		runInfo.rv = falseValue
+	}
+}
+
+// invokeComparisonOperator evaluates a comparison operator.
+func (runInfo *runInfoStruct) invokeComparisonOperator(operator *ast.ComparisonOperator) {
+	runInfo.expr = operator.LHS
+	runInfo.invokeExpr()
+	if runInfo.err != nil {
+		return
+	}
+	if runInfo.rv.Kind() == reflect.Interface && !runInfo.rv.IsNil() {
+		runInfo.rv = runInfo.rv.Elem()
+	}
+	lhsV := runInfo.rv
+
+	runInfo.expr = operator.RHS
+	runInfo.invokeExpr()
+	if runInfo.err != nil {
+		return
+	}
+	if runInfo.rv.Kind() == reflect.Interface && !runInfo.rv.IsNil() {
+		runInfo.rv = runInfo.rv.Elem()
+	}
+
+	var result bool
+	switch operator.Operator {
+	case "==":
+		result = equal(lhsV, runInfo.rv)
+	case "!=":
+		result = !equal(lhsV, runInfo.rv)
+	case "<":
+		// integers are compared as integers to keep full int64 precision
+		if isIntKind(lhsV) && isIntKind(runInfo.rv) {
+			result = lhsV.Int() < runInfo.rv.Int()
+		} else {
+			result = toFloat64(lhsV) < toFloat64(runInfo.rv)
+		}
+	case "<=":
+		if isIntKind(lhsV) && isIntKind(runInfo.rv) {
+			result = lhsV.Int() <= runInfo.rv.Int()
+		} else {
+			result = toFloat64(lhsV) <= toFloat64(runInfo.rv)
+		}
+	case ">":
+		if isIntKind(lhsV) && isIntKind(runInfo.rv) {
+			result = lhsV.Int() > runInfo.rv.Int()
+		} else {
+			result = toFloat64(lhsV) > toFloat64(runInfo.rv)
+		}
+	case ">=":
+		if isIntKind(lhsV) && isIntKind(runInfo.rv) {
+			result = lhsV.Int() >= runInfo.rv.Int()
+		} else {
+			result = toFloat64(lhsV) >= toFloat64(runInfo.rv)
+		}
+	default:
+		runInfo.err = newStringError(operator, "unknown operator")
+		runInfo.rv = nilValue
+		return
+	}
+
+	if result {
+		runInfo.rv = trueValue
+	} else {
+		runInfo.rv = falseValue
+	}
+}
+
+// invokeAddOperator evaluates an add operator.
+func (runInfo *runInfoStruct) invokeAddOperator(operator *ast.AddOperator) {
+	runInfo.expr = operator.LHS
+	runInfo.invokeExpr()
+	if runInfo.err != nil {
+		return
+	}
+	if runInfo.rv.Kind() == reflect.Interface && !runInfo.rv.IsNil() {
+		runInfo.rv = runInfo.rv.Elem()
+	}
+	lhsV := runInfo.rv
+
+	runInfo.expr = operator.RHS
+	runInfo.invokeExpr()
+	if runInfo.err != nil {
+		return
+	}
+	if runInfo.rv.Kind() == reflect.Interface && !runInfo.rv.IsNil() {
+		runInfo.rv = runInfo.rv.Elem()
+	}
+
+	switch operator.Operator {
+	case "+":
+		lhsKind := lhsV.Kind()
+		rhsKind := runInfo.rv.Kind()
+
+		if lhsKind == reflect.Slice || lhsKind == reflect.Array {
+			if rhsKind == reflect.Slice || rhsKind == reflect.Array {
+				// append slice to slice
+				runInfo.rv, runInfo.err = appendSlice(operator, lhsV, runInfo.rv)
+				return
+			}
+			// try to append rhs non-slice to lhs slice
+			runInfo.rv, runInfo.err = convertReflectValueToType(runInfo.rv, lhsV.Type().Elem())
+			if runInfo.err != nil {
+				runInfo.err = newStringError(operator, "invalid type conversion")
+				runInfo.rv = nilValue
+				return
+			}
+			runInfo.rv = reflect.Append(lhsV, runInfo.rv)
+			return
+		}
+		if rhsKind == reflect.Slice || rhsKind == reflect.Array {
+			// can not append rhs slice to lhs non-slice
+			runInfo.err = newStringError(operator, "invalid type conversion")
+			runInfo.rv = nilValue
+			return
+		}
+
+		kind := precedenceOfKinds(lhsKind, rhsKind)
+		switch kind {
+		case reflect.String:
+			runInfo.rv = reflect.ValueOf(toString(lhsV) + toString(runInfo.rv))
+		case reflect.Float64, reflect.Float32:
+			runInfo.rv = float64Value(toFloat64(lhsV) + toFloat64(runInfo.rv))
+		default:
+			runInfo.rv = int64Value(toInt64(lhsV) + toInt64(runInfo.rv))
+		}
+
+	case "-":
+		switch lhsV.Kind() {
+		case reflect.Float64, reflect.Float32:
+			runInfo.rv = float64Value(toFloat64(lhsV) - toFloat64(runInfo.rv))
+			return
+		}
+		switch runInfo.rv.Kind() {
+		case reflect.Float64, reflect.Float32:
+			runInfo.rv = float64Value(toFloat64(lhsV) - toFloat64(runInfo.rv))
+		default:
+			runInfo.rv = int64Value(toInt64(lhsV) - toInt64(runInfo.rv))
+		}
+
+	case "|":
+		runInfo.rv = int64Value(toInt64(lhsV) | toInt64(runInfo.rv))
+	default:
+		runInfo.err = newStringError(operator, "unknown operator")
+		runInfo.rv = nilValue
+	}
+}
+
+// invokeMultiplyOperator evaluates a multiply operator.
+func (runInfo *runInfoStruct) invokeMultiplyOperator(operator *ast.MultiplyOperator) {
+	runInfo.expr = operator.LHS
+	runInfo.invokeExpr()
+	if runInfo.err != nil {
+		return
+	}
+	if runInfo.rv.Kind() == reflect.Interface && !runInfo.rv.IsNil() {
+		runInfo.rv = runInfo.rv.Elem()
+	}
+	lhsV := runInfo.rv
+
+	runInfo.expr = operator.RHS
+	runInfo.invokeExpr()
+	if runInfo.err != nil {
+		return
+	}
+	if runInfo.rv.Kind() == reflect.Interface && !runInfo.rv.IsNil() {
+		runInfo.rv = runInfo.rv.Elem()
+	}
+
+	switch operator.Operator {
+	case "*":
+		if lhsV.Kind() == reflect.String && (runInfo.rv.Kind() == reflect.Int || runInfo.rv.Kind() == reflect.Int32 || runInfo.rv.Kind() == reflect.Int64) {
+			count := toInt64(runInfo.rv)
+			if count < 0 {
+				runInfo.err = newStringError(operator, "negative repeat count")
+				runInfo.rv = nilValue
+				return
+			}
+			runInfo.rv = reflect.ValueOf(strings.Repeat(toString(lhsV), int(count)))
+			return
+		}
+		if lhsV.Kind() == reflect.Float64 || runInfo.rv.Kind() == reflect.Float64 {
+			runInfo.rv = float64Value(toFloat64(lhsV) * toFloat64(runInfo.rv))
+			return
+		}
+		runInfo.rv = int64Value(toInt64(lhsV) * toInt64(runInfo.rv))
+	case "/":
+		runInfo.rv = float64Value(toFloat64(lhsV) / toFloat64(runInfo.rv))
+	case "%":
+		rhs := toInt64(runInfo.rv)
+		if rhs == 0 {
+			runInfo.err = newStringError(operator, "integer divide by zero")
+			runInfo.rv = nilValue
+			return
+		}
+		runInfo.rv = int64Value(toInt64(lhsV) % rhs)
+	case ">>":
+		runInfo.rv = int64Value(toInt64(lhsV) >> uint64(toInt64(runInfo.rv)))
+	case "<<":
+		runInfo.rv = int64Value(toInt64(lhsV) << uint64(toInt64(runInfo.rv)))
+	case "&":
+		runInfo.rv = int64Value(toInt64(lhsV) & toInt64(runInfo.rv))
+
+	default:
+		runInfo.err = newStringError(operator, "unknown operator")
+		runInfo.rv = nilValue
 	}
 }

--- a/vm/vmStmt.go
+++ b/vm/vmStmt.go
@@ -65,30 +65,7 @@ func (runInfo *runInfoStruct) runSingleStmt() {
 
 	// StmtsStmt
 	case *ast.StmtsStmt:
-		for _, stmt := range stmt.Stmts {
-			switch stmt.(type) {
-			case *ast.BreakStmt:
-				runInfo.err = ErrBreak
-				return
-			case *ast.ContinueStmt:
-				runInfo.err = ErrContinue
-				return
-			case *ast.ReturnStmt:
-				runInfo.stmt = stmt
-				runInfo.runSingleStmt()
-				if runInfo.err != nil {
-					return
-				}
-				runInfo.err = ErrReturn
-				return
-			default:
-				runInfo.stmt = stmt
-				runInfo.runSingleStmt()
-				if runInfo.err != nil {
-					return
-				}
-			}
-		}
+		runInfo.runStmtsStmt(stmt)
 
 	// ExprStmt
 	case *ast.ExprStmt:
@@ -97,507 +74,39 @@ func (runInfo *runInfoStruct) runSingleStmt() {
 
 	// VarStmt
 	case *ast.VarStmt:
-		// get right side expression values
-		rvs := make([]reflect.Value, len(stmt.Exprs))
-		var i int
-		for i, runInfo.expr = range stmt.Exprs {
-			runInfo.invokeExpr()
-			if runInfo.err != nil {
-				return
-			}
-			if env, ok := runInfo.rv.Interface().(*env.Env); ok {
-				rvs[i] = reflect.ValueOf(env.DeepCopy())
-			} else {
-				rvs[i] = runInfo.rv
-			}
-		}
-
-		if len(rvs) == 1 && len(stmt.Names) > 1 {
-			// only one right side value but many left side names
-			value := rvs[0]
-			if value.Kind() == reflect.Interface && !value.IsNil() {
-				value = value.Elem()
-			}
-			if (value.Kind() == reflect.Slice || value.Kind() == reflect.Array) && value.Len() > 0 {
-				// value is slice/array, add each value to left side names
-				for i := 0; i < value.Len() && i < len(stmt.Names); i++ {
-					runInfo.env.DefineValue(stmt.Names[i], value.Index(i))
-				}
-				// return last value of slice/array
-				runInfo.rv = value.Index(value.Len() - 1)
-				return
-			}
-		}
-
-		// define all names with right side values
-		for i = 0; i < len(rvs) && i < len(stmt.Names); i++ {
-			runInfo.env.DefineValue(stmt.Names[i], rvs[i])
-		}
-
-		// return last right side value
-		runInfo.rv = rvs[len(rvs)-1]
+		runInfo.runVarStmt(stmt)
 
 	// LetsStmt
 	case *ast.LetsStmt:
-		if len(stmt.LHSS) < 1 || len(stmt.RHSS) < 1 {
-			runInfo.err = newStringError(stmt, "invalid operation")
-			runInfo.rv = nilValue
-			return
-		}
-		// get right side expression values
-		rvs := make([]reflect.Value, len(stmt.RHSS))
-		var i int
-		for i, runInfo.expr = range stmt.RHSS {
-			runInfo.invokeExpr()
-			if runInfo.err != nil {
-				return
-			}
-			if env, ok := runInfo.rv.Interface().(*env.Env); ok {
-				rvs[i] = reflect.ValueOf(env.DeepCopy())
-			} else {
-				rvs[i] = runInfo.rv
-			}
-		}
-
-		if len(rvs) == 1 && len(stmt.LHSS) > 1 {
-			// only one right side value but many left side expressions
-			value := rvs[0]
-			if value.Kind() == reflect.Interface && !value.IsNil() {
-				value = value.Elem()
-			}
-			if (value.Kind() == reflect.Slice || value.Kind() == reflect.Array) && value.Len() > 0 {
-				// value is slice/array, add each value to left side expression
-				for i := 0; i < value.Len() && i < len(stmt.LHSS); i++ {
-					runInfo.rv = value.Index(i)
-					runInfo.expr = stmt.LHSS[i]
-					runInfo.invokeLetExpr()
-					if runInfo.err != nil {
-						return
-					}
-				}
-				// return last value of slice/array
-				runInfo.rv = value.Index(value.Len() - 1)
-				return
-			}
-		}
-
-		// invoke all left side expressions with right side values
-		for i = 0; i < len(rvs) && i < len(stmt.LHSS); i++ {
-			value := rvs[i]
-			if value.Kind() == reflect.Interface && !value.IsNil() {
-				value = value.Elem()
-			}
-			runInfo.rv = value
-			runInfo.expr = stmt.LHSS[i]
-			runInfo.invokeLetExpr()
-			if runInfo.err != nil {
-				return
-			}
-		}
-
-		// return last right side value
-		runInfo.rv = rvs[len(rvs)-1]
+		runInfo.runLetsStmt(stmt)
 
 	// LetMapItemStmt
 	case *ast.LetMapItemStmt:
-		runInfo.expr = stmt.RHS
-		runInfo.invokeExpr()
-		if runInfo.err != nil {
-			return
-		}
-		var rvs []reflect.Value
-		if isNil(runInfo.rv) {
-			rvs = []reflect.Value{nilValue, falseValue}
-		} else {
-			rvs = []reflect.Value{runInfo.rv, trueValue}
-		}
-		var i int
-		for i, runInfo.expr = range stmt.LHSS {
-			runInfo.rv = rvs[i]
-			if runInfo.rv.Kind() == reflect.Interface && !runInfo.rv.IsNil() {
-				runInfo.rv = runInfo.rv.Elem()
-			}
-			runInfo.invokeLetExpr()
-			if runInfo.err != nil {
-				return
-			}
-		}
-		runInfo.rv = rvs[0]
+		runInfo.runLetMapItemStmt(stmt)
 
 	// IfStmt
 	case *ast.IfStmt:
-		// if
-		runInfo.expr = stmt.If
-		runInfo.invokeExpr()
-		if runInfo.err != nil {
-			return
-		}
-
-		env := runInfo.env
-
-		if toBool(runInfo.rv) {
-			// then
-			runInfo.rv = nilValue
-			runInfo.stmt = stmt.Then
-			runInfo.env = env.NewEnv()
-			runInfo.runSingleStmt()
-			runInfo.env = env
-			return
-		}
-
-		for _, statement := range stmt.ElseIf {
-			elseIf := statement.(*ast.IfStmt)
-
-			// else if - if
-			runInfo.env = env.NewEnv()
-			runInfo.expr = elseIf.If
-			runInfo.invokeExpr()
-			if runInfo.err != nil {
-				runInfo.env = env
-				return
-			}
-
-			if !toBool(runInfo.rv) {
-				continue
-			}
-
-			// else if - then
-			runInfo.rv = nilValue
-			runInfo.stmt = elseIf.Then
-			runInfo.env = env.NewEnv()
-			runInfo.runSingleStmt()
-			runInfo.env = env
-			return
-		}
-
-		if stmt.Else != nil {
-			// else
-			runInfo.rv = nilValue
-			runInfo.stmt = stmt.Else
-			runInfo.env = env.NewEnv()
-			runInfo.runSingleStmt()
-		}
-
-		runInfo.env = env
+		runInfo.runIfStmt(stmt)
 
 	// TryStmt
 	case *ast.TryStmt:
-		// only the try statement will ignore any error except ErrInterrupt
-		// all other parts will return the error
-
-		env := runInfo.env
-		runInfo.env = env.NewEnv()
-
-		runInfo.stmt = stmt.Try
-		runInfo.runSingleStmt()
-
-		if runInfo.err != nil {
-			if runInfo.err == ErrInterrupt {
-				runInfo.env = env
-				return
-			}
-
-			// Catch
-			runInfo.stmt = stmt.Catch
-			if stmt.Var != "" {
-				runInfo.env.DefineValue(stmt.Var, reflect.ValueOf(runInfo.err))
-			}
-			runInfo.err = nil
-			runInfo.runSingleStmt()
-			if runInfo.err != nil {
-				runInfo.env = env
-				return
-			}
-		}
-
-		if stmt.Finally != nil {
-			// Finally
-			runInfo.stmt = stmt.Finally
-			runInfo.runSingleStmt()
-		}
-
-		runInfo.env = env
+		runInfo.runTryStmt(stmt)
 
 	// LoopStmt
 	case *ast.LoopStmt:
-		env := runInfo.env
-		runInfo.env = env.NewEnv()
-
-		for {
-			select {
-			case <-runInfo.ctx.Done():
-				runInfo.err = ErrInterrupt
-				runInfo.rv = nilValue
-				runInfo.env = env
-				return
-			default:
-			}
-
-			if stmt.Expr != nil {
-				runInfo.expr = stmt.Expr
-				runInfo.invokeExpr()
-				if runInfo.err != nil {
-					break
-				}
-				if !toBool(runInfo.rv) {
-					break
-				}
-			}
-
-			runInfo.stmt = stmt.Stmt
-			runInfo.runSingleStmt()
-			if runInfo.err != nil {
-				if runInfo.err == ErrContinue {
-					runInfo.err = nil
-					continue
-				}
-				if runInfo.err == ErrReturn {
-					runInfo.env = env
-					return
-				}
-				if runInfo.err == ErrBreak {
-					runInfo.err = nil
-				}
-				break
-			}
-		}
-
-		runInfo.rv = nilValue
-		runInfo.env = env
+		runInfo.runLoopStmt(stmt)
 
 	// ForStmt
 	case *ast.ForStmt:
-		runInfo.expr = stmt.Value
-		runInfo.invokeExpr()
-		value := runInfo.rv
-		if runInfo.err != nil {
-			return
-		}
-		if value.Kind() == reflect.Interface && !value.IsNil() {
-			value = value.Elem()
-		}
-
-		env := runInfo.env
-		runInfo.env = env.NewEnv()
-
-		switch value.Kind() {
-		case reflect.Slice, reflect.Array:
-			for i := 0; i < value.Len(); i++ {
-				select {
-				case <-runInfo.ctx.Done():
-					runInfo.err = ErrInterrupt
-					runInfo.rv = nilValue
-					runInfo.env = env
-					return
-				default:
-				}
-
-				iv := value.Index(i)
-				if iv.Kind() == reflect.Interface && !iv.IsNil() {
-					iv = iv.Elem()
-				}
-				if iv.Kind() == reflect.Ptr {
-					iv = iv.Elem()
-				}
-				runInfo.env.DefineValue(stmt.Vars[0], iv)
-
-				runInfo.stmt = stmt.Stmt
-				runInfo.runSingleStmt()
-				if runInfo.err != nil {
-					if runInfo.err == ErrContinue {
-						runInfo.err = nil
-						continue
-					}
-					if runInfo.err == ErrReturn {
-						runInfo.env = env
-						return
-					}
-					if runInfo.err == ErrBreak {
-						runInfo.err = nil
-					}
-					break
-				}
-			}
-			runInfo.rv = nilValue
-			runInfo.env = env
-
-		case reflect.Map:
-			keys := value.MapKeys()
-			for i := 0; i < len(keys); i++ {
-				select {
-				case <-runInfo.ctx.Done():
-					runInfo.err = ErrInterrupt
-					runInfo.rv = nilValue
-					runInfo.env = env
-					return
-				default:
-				}
-
-				runInfo.env.DefineValue(stmt.Vars[0], keys[i])
-
-				if len(stmt.Vars) > 1 {
-					runInfo.env.DefineValue(stmt.Vars[1], value.MapIndex(keys[i]))
-				}
-
-				runInfo.stmt = stmt.Stmt
-				runInfo.runSingleStmt()
-				if runInfo.err != nil {
-					if runInfo.err == ErrContinue {
-						runInfo.err = nil
-						continue
-					}
-					if runInfo.err == ErrReturn {
-						runInfo.env = env
-						return
-					}
-					if runInfo.err == ErrBreak {
-						runInfo.err = nil
-					}
-					break
-				}
-			}
-			runInfo.rv = nilValue
-			runInfo.env = env
-
-		case reflect.Chan:
-			var chosen int
-			var ok bool
-			for {
-				cases := []reflect.SelectCase{{
-					Dir:  reflect.SelectRecv,
-					Chan: reflect.ValueOf(runInfo.ctx.Done()),
-				}, {
-					Dir:  reflect.SelectRecv,
-					Chan: value,
-				}}
-				chosen, runInfo.rv, ok = reflect.Select(cases)
-				if chosen == 0 {
-					runInfo.err = ErrInterrupt
-					runInfo.rv = nilValue
-					break
-				}
-				if !ok {
-					break
-				}
-
-				if runInfo.rv.Kind() == reflect.Interface && !runInfo.rv.IsNil() {
-					runInfo.rv = runInfo.rv.Elem()
-				}
-				if runInfo.rv.Kind() == reflect.Ptr {
-					runInfo.rv = runInfo.rv.Elem()
-				}
-
-				runInfo.env.DefineValue(stmt.Vars[0], runInfo.rv)
-
-				runInfo.stmt = stmt.Stmt
-				runInfo.runSingleStmt()
-				if runInfo.err != nil {
-					if runInfo.err == ErrContinue {
-						runInfo.err = nil
-						continue
-					}
-					if runInfo.err == ErrReturn {
-						runInfo.env = env
-						return
-					}
-					if runInfo.err == ErrBreak {
-						runInfo.err = nil
-					}
-					break
-				}
-			}
-			runInfo.rv = nilValue
-			runInfo.env = env
-
-		default:
-			runInfo.err = newStringError(stmt, "for cannot loop over type "+value.Kind().String())
-			runInfo.rv = nilValue
-			runInfo.env = env
-		}
+		runInfo.runForStmt(stmt)
 
 	// CForStmt
 	case *ast.CForStmt:
-		env := runInfo.env
-		runInfo.env = env.NewEnv()
-
-		if stmt.Stmt1 != nil {
-			runInfo.stmt = stmt.Stmt1
-			runInfo.runSingleStmt()
-			if runInfo.err != nil {
-				runInfo.env = env
-				return
-			}
-		}
-
-		for {
-			select {
-			case <-runInfo.ctx.Done():
-				runInfo.err = ErrInterrupt
-				runInfo.rv = nilValue
-				runInfo.env = env
-				return
-			default:
-			}
-
-			if stmt.Expr2 != nil {
-				runInfo.expr = stmt.Expr2
-				runInfo.invokeExpr()
-				if runInfo.err != nil {
-					break
-				}
-				if !toBool(runInfo.rv) {
-					break
-				}
-			}
-
-			runInfo.stmt = stmt.Stmt
-			runInfo.runSingleStmt()
-			if runInfo.err == ErrContinue {
-				runInfo.err = nil
-			}
-			if runInfo.err != nil {
-				if runInfo.err == ErrReturn {
-					runInfo.env = env
-					return
-				}
-				if runInfo.err == ErrBreak {
-					runInfo.err = nil
-				}
-				break
-			}
-
-			if stmt.Expr3 != nil {
-				runInfo.expr = stmt.Expr3
-				runInfo.invokeExpr()
-				if runInfo.err != nil {
-					break
-				}
-			}
-		}
-		runInfo.rv = nilValue
-		runInfo.env = env
+		runInfo.runCForStmt(stmt)
 
 	// ReturnStmt
 	case *ast.ReturnStmt:
-		switch len(stmt.Exprs) {
-		case 0:
-			runInfo.rv = nilValue
-			return
-		case 1:
-			runInfo.expr = stmt.Exprs[0]
-			runInfo.invokeExpr()
-			return
-		}
-		rvs := make([]interface{}, len(stmt.Exprs))
-		var i int
-		for i, runInfo.expr = range stmt.Exprs {
-			runInfo.invokeExpr()
-			if runInfo.err != nil {
-				return
-			}
-			rvs[i] = runInfo.rv.Interface()
-		}
-		runInfo.rv = reflect.ValueOf(rvs)
+		runInfo.runReturnStmt(stmt)
 
 	// ThrowStmt
 	case *ast.ThrowStmt:
@@ -610,57 +119,11 @@ func (runInfo *runInfoStruct) runSingleStmt() {
 
 	// ModuleStmt
 	case *ast.ModuleStmt:
-		e := runInfo.env
-		runInfo.env, runInfo.err = e.NewModule(stmt.Name)
-		if runInfo.err != nil {
-			return
-		}
-		runInfo.stmt = stmt.Stmt
-		runInfo.runSingleStmt()
-		runInfo.env = e
-		if runInfo.err != nil {
-			return
-		}
-		runInfo.rv = nilValue
+		runInfo.runModuleStmt(stmt)
 
 	// SwitchStmt
 	case *ast.SwitchStmt:
-		env := runInfo.env
-		runInfo.env = env.NewEnv()
-
-		runInfo.expr = stmt.Expr
-		runInfo.invokeExpr()
-		if runInfo.err != nil {
-			runInfo.env = env
-			return
-		}
-		value := runInfo.rv
-
-		for _, switchCaseStmt := range stmt.Cases {
-			caseStmt := switchCaseStmt.(*ast.SwitchCaseStmt)
-			for _, runInfo.expr = range caseStmt.Exprs {
-				runInfo.invokeExpr()
-				if runInfo.err != nil {
-					runInfo.env = env
-					return
-				}
-				if equal(runInfo.rv, value) {
-					runInfo.stmt = caseStmt.Stmt
-					runInfo.runSingleStmt()
-					runInfo.env = env
-					return
-				}
-			}
-		}
-
-		if stmt.Default == nil {
-			runInfo.rv = nilValue
-		} else {
-			runInfo.stmt = stmt.Default
-			runInfo.runSingleStmt()
-		}
-
-		runInfo.env = env
+		runInfo.runSwitchStmt(stmt)
 
 	// GoroutineStmt
 	case *ast.GoroutineStmt:
@@ -669,145 +132,15 @@ func (runInfo *runInfoStruct) runSingleStmt() {
 
 	// DeleteStmt
 	case *ast.DeleteStmt:
-		runInfo.expr = stmt.Item
-		runInfo.invokeExpr()
-		if runInfo.err != nil {
-			return
-		}
-		item := runInfo.rv
-
-		if stmt.Key != nil {
-			runInfo.expr = stmt.Key
-			runInfo.invokeExpr()
-			if runInfo.err != nil {
-				return
-			}
-		}
-
-		if item.Kind() == reflect.Interface && !item.IsNil() {
-			item = item.Elem()
-		}
-
-		switch item.Kind() {
-		case reflect.String:
-			if stmt.Key != nil && runInfo.rv.Kind() == reflect.Bool && runInfo.rv.Bool() {
-				runInfo.env.DeleteGlobal(item.String())
-				runInfo.rv = nilValue
-				return
-			}
-			runInfo.env.Delete(item.String())
-			runInfo.rv = nilValue
-
-		case reflect.Map:
-			if stmt.Key == nil {
-				runInfo.err = newStringError(stmt, "second argument to delete cannot be nil for map")
-				runInfo.rv = nilValue
-				return
-			}
-			if item.IsNil() {
-				runInfo.rv = nilValue
-				return
-			}
-			runInfo.rv, runInfo.err = convertReflectValueToType(runInfo.rv, item.Type().Key())
-			if runInfo.err != nil {
-				runInfo.err = newStringError(stmt, "cannot use type "+item.Type().Key().String()+" as type "+runInfo.rv.Type().String()+" in delete")
-				runInfo.rv = nilValue
-				return
-			}
-			if !isHashable(runInfo.rv) {
-				runInfo.err = newStringError(stmt, "type "+hashableTypeString(runInfo.rv)+" cannot be used as map key in delete")
-				runInfo.rv = nilValue
-				return
-			}
-			item.SetMapIndex(runInfo.rv, reflect.Value{})
-			runInfo.rv = nilValue
-		default:
-			runInfo.err = newStringError(stmt, "first argument to delete cannot be type "+item.Kind().String())
-			runInfo.rv = nilValue
-		}
+		runInfo.runDeleteStmt(stmt)
 
 	// CloseStmt
 	case *ast.CloseStmt:
-		runInfo.expr = stmt.Expr
-		runInfo.invokeExpr()
-		if runInfo.err != nil {
-			return
-		}
-		if runInfo.rv.Kind() == reflect.Chan {
-			ch := runInfo.rv
-			runInfo.rv = nilValue
-			if !runInfo.options.Debug {
-				// captures panic
-				defer recoverFunc(runInfo)
-			}
-			ch.Close()
-			return
-		}
-		runInfo.err = newStringError(stmt, "type cannot be "+runInfo.rv.Kind().String()+" for close")
-		runInfo.rv = nilValue
+		runInfo.runCloseStmt(stmt)
 
 	// ChanStmt
 	case *ast.ChanStmt:
-		runInfo.expr = stmt.RHS
-		runInfo.invokeExpr()
-		if runInfo.err != nil {
-			return
-		}
-		if runInfo.rv.Kind() == reflect.Interface && !runInfo.rv.IsNil() {
-			runInfo.rv = runInfo.rv.Elem()
-		}
-
-		if runInfo.rv.Kind() != reflect.Chan {
-			// rhs is not channel
-			runInfo.err = newStringError(stmt, "receive from non-chan type "+runInfo.rv.Kind().String())
-			runInfo.rv = nilValue
-			return
-		}
-
-		// rhs is channel
-		// receive from rhs channel
-		rhs := runInfo.rv
-		cases := []reflect.SelectCase{{
-			Dir:  reflect.SelectRecv,
-			Chan: reflect.ValueOf(runInfo.ctx.Done()),
-		}, {
-			Dir:  reflect.SelectRecv,
-			Chan: rhs,
-		}}
-		var chosen int
-		var ok bool
-		chosen, runInfo.rv, ok = reflect.Select(cases)
-		if chosen == 0 {
-			runInfo.err = ErrInterrupt
-			runInfo.rv = nilValue
-			return
-		}
-
-		rhs = runInfo.rv // store rv in rhs temporarily
-
-		if stmt.OkExpr != nil {
-			// set ok to OkExpr
-			if ok {
-				runInfo.rv = trueValue
-			} else {
-				runInfo.rv = falseValue
-			}
-			runInfo.expr = stmt.OkExpr
-			runInfo.invokeLetExpr()
-			// TODO: ok to ignore error?
-		}
-
-		if ok {
-			// set rv to lhs
-			runInfo.rv = rhs
-			runInfo.expr = stmt.LHS
-			runInfo.invokeLetExpr()
-			if runInfo.err != nil {
-				return
-			}
-		} else {
-			runInfo.rv = nilValue
-		}
+		runInfo.runChanStmt(stmt)
 
 	// default
 	default:
@@ -815,4 +148,751 @@ func (runInfo *runInfoStruct) runSingleStmt() {
 		runInfo.rv = nilValue
 	}
 
+}
+
+// runStmtsStmt executes a list of statements.
+func (runInfo *runInfoStruct) runStmtsStmt(stmts *ast.StmtsStmt) {
+	for _, stmt := range stmts.Stmts {
+		switch stmt.(type) {
+		case *ast.BreakStmt:
+			runInfo.err = ErrBreak
+			return
+		case *ast.ContinueStmt:
+			runInfo.err = ErrContinue
+			return
+		case *ast.ReturnStmt:
+			runInfo.stmt = stmt
+			runInfo.runSingleStmt()
+			if runInfo.err != nil {
+				return
+			}
+			runInfo.err = ErrReturn
+			return
+		default:
+			runInfo.stmt = stmt
+			runInfo.runSingleStmt()
+			if runInfo.err != nil {
+				return
+			}
+		}
+	}
+}
+
+// runVarStmt executes a var statement.
+func (runInfo *runInfoStruct) runVarStmt(stmt *ast.VarStmt) {
+	// get right side expression values
+	rvs := make([]reflect.Value, len(stmt.Exprs))
+	var i int
+	for i, runInfo.expr = range stmt.Exprs {
+		runInfo.invokeExpr()
+		if runInfo.err != nil {
+			return
+		}
+		if env, ok := runInfo.rv.Interface().(*env.Env); ok {
+			rvs[i] = reflect.ValueOf(env.DeepCopy())
+		} else {
+			rvs[i] = runInfo.rv
+		}
+	}
+
+	if len(rvs) == 1 && len(stmt.Names) > 1 {
+		// only one right side value but many left side names
+		value := rvs[0]
+		if value.Kind() == reflect.Interface && !value.IsNil() {
+			value = value.Elem()
+		}
+		if (value.Kind() == reflect.Slice || value.Kind() == reflect.Array) && value.Len() > 0 {
+			// value is slice/array, add each value to left side names
+			for i := 0; i < value.Len() && i < len(stmt.Names); i++ {
+				runInfo.env.DefineValue(stmt.Names[i], value.Index(i))
+			}
+			// return last value of slice/array
+			runInfo.rv = value.Index(value.Len() - 1)
+			return
+		}
+	}
+
+	// define all names with right side values
+	for i = 0; i < len(rvs) && i < len(stmt.Names); i++ {
+		runInfo.env.DefineValue(stmt.Names[i], rvs[i])
+	}
+
+	// return last right side value
+	runInfo.rv = rvs[len(rvs)-1]
+}
+
+// runLetsStmt executes a lets statement.
+func (runInfo *runInfoStruct) runLetsStmt(stmt *ast.LetsStmt) {
+	if len(stmt.LHSS) < 1 || len(stmt.RHSS) < 1 {
+		runInfo.err = newStringError(stmt, "invalid operation")
+		runInfo.rv = nilValue
+		return
+	}
+	// get right side expression values
+	rvs := make([]reflect.Value, len(stmt.RHSS))
+	var i int
+	for i, runInfo.expr = range stmt.RHSS {
+		runInfo.invokeExpr()
+		if runInfo.err != nil {
+			return
+		}
+		if env, ok := runInfo.rv.Interface().(*env.Env); ok {
+			rvs[i] = reflect.ValueOf(env.DeepCopy())
+		} else {
+			rvs[i] = runInfo.rv
+		}
+	}
+
+	if len(rvs) == 1 && len(stmt.LHSS) > 1 {
+		// only one right side value but many left side expressions
+		value := rvs[0]
+		if value.Kind() == reflect.Interface && !value.IsNil() {
+			value = value.Elem()
+		}
+		if (value.Kind() == reflect.Slice || value.Kind() == reflect.Array) && value.Len() > 0 {
+			// value is slice/array, add each value to left side expression
+			for i := 0; i < value.Len() && i < len(stmt.LHSS); i++ {
+				runInfo.rv = value.Index(i)
+				runInfo.expr = stmt.LHSS[i]
+				runInfo.invokeLetExpr()
+				if runInfo.err != nil {
+					return
+				}
+			}
+			// return last value of slice/array
+			runInfo.rv = value.Index(value.Len() - 1)
+			return
+		}
+	}
+
+	// invoke all left side expressions with right side values
+	for i = 0; i < len(rvs) && i < len(stmt.LHSS); i++ {
+		value := rvs[i]
+		if value.Kind() == reflect.Interface && !value.IsNil() {
+			value = value.Elem()
+		}
+		runInfo.rv = value
+		runInfo.expr = stmt.LHSS[i]
+		runInfo.invokeLetExpr()
+		if runInfo.err != nil {
+			return
+		}
+	}
+
+	// return last right side value
+	runInfo.rv = rvs[len(rvs)-1]
+}
+
+// runLetMapItemStmt executes a let map item statement.
+func (runInfo *runInfoStruct) runLetMapItemStmt(stmt *ast.LetMapItemStmt) {
+	runInfo.expr = stmt.RHS
+	runInfo.invokeExpr()
+	if runInfo.err != nil {
+		return
+	}
+	var rvs []reflect.Value
+	if isNil(runInfo.rv) {
+		rvs = []reflect.Value{nilValue, falseValue}
+	} else {
+		rvs = []reflect.Value{runInfo.rv, trueValue}
+	}
+	var i int
+	for i, runInfo.expr = range stmt.LHSS {
+		runInfo.rv = rvs[i]
+		if runInfo.rv.Kind() == reflect.Interface && !runInfo.rv.IsNil() {
+			runInfo.rv = runInfo.rv.Elem()
+		}
+		runInfo.invokeLetExpr()
+		if runInfo.err != nil {
+			return
+		}
+	}
+	runInfo.rv = rvs[0]
+}
+
+// runIfStmt executes an if statement.
+func (runInfo *runInfoStruct) runIfStmt(stmt *ast.IfStmt) {
+	// if
+	runInfo.expr = stmt.If
+	runInfo.invokeExpr()
+	if runInfo.err != nil {
+		return
+	}
+
+	env := runInfo.env
+
+	if toBool(runInfo.rv) {
+		// then
+		runInfo.rv = nilValue
+		runInfo.stmt = stmt.Then
+		runInfo.env = env.NewEnv()
+		runInfo.runSingleStmt()
+		runInfo.env = env
+		return
+	}
+
+	for _, statement := range stmt.ElseIf {
+		elseIf := statement.(*ast.IfStmt)
+
+		// else if - if
+		runInfo.env = env.NewEnv()
+		runInfo.expr = elseIf.If
+		runInfo.invokeExpr()
+		if runInfo.err != nil {
+			runInfo.env = env
+			return
+		}
+
+		if !toBool(runInfo.rv) {
+			continue
+		}
+
+		// else if - then
+		runInfo.rv = nilValue
+		runInfo.stmt = elseIf.Then
+		runInfo.env = env.NewEnv()
+		runInfo.runSingleStmt()
+		runInfo.env = env
+		return
+	}
+
+	if stmt.Else != nil {
+		// else
+		runInfo.rv = nilValue
+		runInfo.stmt = stmt.Else
+		runInfo.env = env.NewEnv()
+		runInfo.runSingleStmt()
+	}
+
+	runInfo.env = env
+}
+
+// runTryStmt executes a try statement.
+func (runInfo *runInfoStruct) runTryStmt(stmt *ast.TryStmt) {
+	// only the try statement will ignore any error except ErrInterrupt
+	// all other parts will return the error
+
+	env := runInfo.env
+	runInfo.env = env.NewEnv()
+
+	runInfo.stmt = stmt.Try
+	runInfo.runSingleStmt()
+
+	if runInfo.err != nil {
+		if runInfo.err == ErrInterrupt {
+			runInfo.env = env
+			return
+		}
+
+		// Catch
+		runInfo.stmt = stmt.Catch
+		if stmt.Var != "" {
+			runInfo.env.DefineValue(stmt.Var, reflect.ValueOf(runInfo.err))
+		}
+		runInfo.err = nil
+		runInfo.runSingleStmt()
+		if runInfo.err != nil {
+			runInfo.env = env
+			return
+		}
+	}
+
+	if stmt.Finally != nil {
+		// Finally
+		runInfo.stmt = stmt.Finally
+		runInfo.runSingleStmt()
+	}
+
+	runInfo.env = env
+}
+
+// runLoopStmt executes a loop statement.
+func (runInfo *runInfoStruct) runLoopStmt(stmt *ast.LoopStmt) {
+	env := runInfo.env
+	runInfo.env = env.NewEnv()
+
+	for {
+		select {
+		case <-runInfo.ctx.Done():
+			runInfo.err = ErrInterrupt
+			runInfo.rv = nilValue
+			runInfo.env = env
+			return
+		default:
+		}
+
+		if stmt.Expr != nil {
+			runInfo.expr = stmt.Expr
+			runInfo.invokeExpr()
+			if runInfo.err != nil {
+				break
+			}
+			if !toBool(runInfo.rv) {
+				break
+			}
+		}
+
+		runInfo.stmt = stmt.Stmt
+		runInfo.runSingleStmt()
+		if runInfo.err != nil {
+			if runInfo.err == ErrContinue {
+				runInfo.err = nil
+				continue
+			}
+			if runInfo.err == ErrReturn {
+				runInfo.env = env
+				return
+			}
+			if runInfo.err == ErrBreak {
+				runInfo.err = nil
+			}
+			break
+		}
+	}
+
+	runInfo.rv = nilValue
+	runInfo.env = env
+}
+
+// runForStmt executes a for statement.
+func (runInfo *runInfoStruct) runForStmt(stmt *ast.ForStmt) {
+	runInfo.expr = stmt.Value
+	runInfo.invokeExpr()
+	value := runInfo.rv
+	if runInfo.err != nil {
+		return
+	}
+	if value.Kind() == reflect.Interface && !value.IsNil() {
+		value = value.Elem()
+	}
+
+	env := runInfo.env
+	runInfo.env = env.NewEnv()
+
+	switch value.Kind() {
+	case reflect.Slice, reflect.Array:
+		runInfo.runForSliceStmt(stmt, value)
+	case reflect.Map:
+		runInfo.runForMapStmt(stmt, value)
+	case reflect.Chan:
+		runInfo.runForChanStmt(stmt, value)
+	default:
+		runInfo.err = newStringError(stmt, "for cannot loop over type "+value.Kind().String())
+		runInfo.rv = nilValue
+	}
+
+	runInfo.env = env
+}
+
+// runForSliceStmt executes a for statement over a slice or array.
+func (runInfo *runInfoStruct) runForSliceStmt(stmt *ast.ForStmt, value reflect.Value) {
+	for i := 0; i < value.Len(); i++ {
+		select {
+		case <-runInfo.ctx.Done():
+			runInfo.err = ErrInterrupt
+			runInfo.rv = nilValue
+			return
+		default:
+		}
+
+		iv := value.Index(i)
+		if iv.Kind() == reflect.Interface && !iv.IsNil() {
+			iv = iv.Elem()
+		}
+		if iv.Kind() == reflect.Ptr {
+			iv = iv.Elem()
+		}
+		runInfo.env.DefineValue(stmt.Vars[0], iv)
+
+		runInfo.stmt = stmt.Stmt
+		runInfo.runSingleStmt()
+		if runInfo.err != nil {
+			if runInfo.err == ErrContinue {
+				runInfo.err = nil
+				continue
+			}
+			if runInfo.err == ErrReturn {
+				return
+			}
+			if runInfo.err == ErrBreak {
+				runInfo.err = nil
+			}
+			break
+		}
+	}
+	runInfo.rv = nilValue
+}
+
+// runForMapStmt executes a for statement over a map.
+func (runInfo *runInfoStruct) runForMapStmt(stmt *ast.ForStmt, value reflect.Value) {
+	keys := value.MapKeys()
+	for i := 0; i < len(keys); i++ {
+		select {
+		case <-runInfo.ctx.Done():
+			runInfo.err = ErrInterrupt
+			runInfo.rv = nilValue
+			return
+		default:
+		}
+
+		runInfo.env.DefineValue(stmt.Vars[0], keys[i])
+
+		if len(stmt.Vars) > 1 {
+			runInfo.env.DefineValue(stmt.Vars[1], value.MapIndex(keys[i]))
+		}
+
+		runInfo.stmt = stmt.Stmt
+		runInfo.runSingleStmt()
+		if runInfo.err != nil {
+			if runInfo.err == ErrContinue {
+				runInfo.err = nil
+				continue
+			}
+			if runInfo.err == ErrReturn {
+				return
+			}
+			if runInfo.err == ErrBreak {
+				runInfo.err = nil
+			}
+			break
+		}
+	}
+	runInfo.rv = nilValue
+}
+
+// runForChanStmt executes a for statement over a channel.
+func (runInfo *runInfoStruct) runForChanStmt(stmt *ast.ForStmt, value reflect.Value) {
+	var chosen int
+	var ok bool
+	for {
+		cases := []reflect.SelectCase{{
+			Dir:  reflect.SelectRecv,
+			Chan: reflect.ValueOf(runInfo.ctx.Done()),
+		}, {
+			Dir:  reflect.SelectRecv,
+			Chan: value,
+		}}
+		chosen, runInfo.rv, ok = reflect.Select(cases)
+		if chosen == 0 {
+			runInfo.err = ErrInterrupt
+			runInfo.rv = nilValue
+			break
+		}
+		if !ok {
+			break
+		}
+
+		if runInfo.rv.Kind() == reflect.Interface && !runInfo.rv.IsNil() {
+			runInfo.rv = runInfo.rv.Elem()
+		}
+		if runInfo.rv.Kind() == reflect.Ptr {
+			runInfo.rv = runInfo.rv.Elem()
+		}
+
+		runInfo.env.DefineValue(stmt.Vars[0], runInfo.rv)
+
+		runInfo.stmt = stmt.Stmt
+		runInfo.runSingleStmt()
+		if runInfo.err != nil {
+			if runInfo.err == ErrContinue {
+				runInfo.err = nil
+				continue
+			}
+			if runInfo.err == ErrReturn {
+				return
+			}
+			if runInfo.err == ErrBreak {
+				runInfo.err = nil
+			}
+			break
+		}
+	}
+	runInfo.rv = nilValue
+}
+
+// runCForStmt executes a C-style for statement.
+func (runInfo *runInfoStruct) runCForStmt(stmt *ast.CForStmt) {
+	env := runInfo.env
+	runInfo.env = env.NewEnv()
+
+	if stmt.Stmt1 != nil {
+		runInfo.stmt = stmt.Stmt1
+		runInfo.runSingleStmt()
+		if runInfo.err != nil {
+			runInfo.env = env
+			return
+		}
+	}
+
+	for {
+		select {
+		case <-runInfo.ctx.Done():
+			runInfo.err = ErrInterrupt
+			runInfo.rv = nilValue
+			runInfo.env = env
+			return
+		default:
+		}
+
+		if stmt.Expr2 != nil {
+			runInfo.expr = stmt.Expr2
+			runInfo.invokeExpr()
+			if runInfo.err != nil {
+				break
+			}
+			if !toBool(runInfo.rv) {
+				break
+			}
+		}
+
+		runInfo.stmt = stmt.Stmt
+		runInfo.runSingleStmt()
+		if runInfo.err == ErrContinue {
+			runInfo.err = nil
+		}
+		if runInfo.err != nil {
+			if runInfo.err == ErrReturn {
+				runInfo.env = env
+				return
+			}
+			if runInfo.err == ErrBreak {
+				runInfo.err = nil
+			}
+			break
+		}
+
+		if stmt.Expr3 != nil {
+			runInfo.expr = stmt.Expr3
+			runInfo.invokeExpr()
+			if runInfo.err != nil {
+				break
+			}
+		}
+	}
+	runInfo.rv = nilValue
+	runInfo.env = env
+}
+
+// runReturnStmt executes a return statement.
+func (runInfo *runInfoStruct) runReturnStmt(stmt *ast.ReturnStmt) {
+	switch len(stmt.Exprs) {
+	case 0:
+		runInfo.rv = nilValue
+		return
+	case 1:
+		runInfo.expr = stmt.Exprs[0]
+		runInfo.invokeExpr()
+		return
+	}
+	rvs := make([]interface{}, len(stmt.Exprs))
+	var i int
+	for i, runInfo.expr = range stmt.Exprs {
+		runInfo.invokeExpr()
+		if runInfo.err != nil {
+			return
+		}
+		rvs[i] = runInfo.rv.Interface()
+	}
+	runInfo.rv = reflect.ValueOf(rvs)
+}
+
+// runModuleStmt executes a module statement.
+func (runInfo *runInfoStruct) runModuleStmt(stmt *ast.ModuleStmt) {
+	e := runInfo.env
+	runInfo.env, runInfo.err = e.NewModule(stmt.Name)
+	if runInfo.err != nil {
+		return
+	}
+	runInfo.stmt = stmt.Stmt
+	runInfo.runSingleStmt()
+	runInfo.env = e
+	if runInfo.err != nil {
+		return
+	}
+	runInfo.rv = nilValue
+}
+
+// runSwitchStmt executes a switch statement.
+func (runInfo *runInfoStruct) runSwitchStmt(stmt *ast.SwitchStmt) {
+	env := runInfo.env
+	runInfo.env = env.NewEnv()
+
+	runInfo.expr = stmt.Expr
+	runInfo.invokeExpr()
+	if runInfo.err != nil {
+		runInfo.env = env
+		return
+	}
+	value := runInfo.rv
+
+	for _, switchCaseStmt := range stmt.Cases {
+		caseStmt := switchCaseStmt.(*ast.SwitchCaseStmt)
+		for _, runInfo.expr = range caseStmt.Exprs {
+			runInfo.invokeExpr()
+			if runInfo.err != nil {
+				runInfo.env = env
+				return
+			}
+			if equal(runInfo.rv, value) {
+				runInfo.stmt = caseStmt.Stmt
+				runInfo.runSingleStmt()
+				runInfo.env = env
+				return
+			}
+		}
+	}
+
+	if stmt.Default == nil {
+		runInfo.rv = nilValue
+	} else {
+		runInfo.stmt = stmt.Default
+		runInfo.runSingleStmt()
+	}
+
+	runInfo.env = env
+}
+
+// runDeleteStmt executes a delete statement.
+func (runInfo *runInfoStruct) runDeleteStmt(stmt *ast.DeleteStmt) {
+	runInfo.expr = stmt.Item
+	runInfo.invokeExpr()
+	if runInfo.err != nil {
+		return
+	}
+	item := runInfo.rv
+
+	if stmt.Key != nil {
+		runInfo.expr = stmt.Key
+		runInfo.invokeExpr()
+		if runInfo.err != nil {
+			return
+		}
+	}
+
+	if item.Kind() == reflect.Interface && !item.IsNil() {
+		item = item.Elem()
+	}
+
+	switch item.Kind() {
+	case reflect.String:
+		if stmt.Key != nil && runInfo.rv.Kind() == reflect.Bool && runInfo.rv.Bool() {
+			runInfo.env.DeleteGlobal(item.String())
+			runInfo.rv = nilValue
+			return
+		}
+		runInfo.env.Delete(item.String())
+		runInfo.rv = nilValue
+
+	case reflect.Map:
+		if stmt.Key == nil {
+			runInfo.err = newStringError(stmt, "second argument to delete cannot be nil for map")
+			runInfo.rv = nilValue
+			return
+		}
+		if item.IsNil() {
+			runInfo.rv = nilValue
+			return
+		}
+		runInfo.rv, runInfo.err = convertReflectValueToType(runInfo.rv, item.Type().Key())
+		if runInfo.err != nil {
+			runInfo.err = newStringError(stmt, "cannot use type "+item.Type().Key().String()+" as type "+runInfo.rv.Type().String()+" in delete")
+			runInfo.rv = nilValue
+			return
+		}
+		if !isHashable(runInfo.rv) {
+			runInfo.err = newStringError(stmt, "type "+hashableTypeString(runInfo.rv)+" cannot be used as map key in delete")
+			runInfo.rv = nilValue
+			return
+		}
+		item.SetMapIndex(runInfo.rv, reflect.Value{})
+		runInfo.rv = nilValue
+	default:
+		runInfo.err = newStringError(stmt, "first argument to delete cannot be type "+item.Kind().String())
+		runInfo.rv = nilValue
+	}
+}
+
+// runCloseStmt executes a close statement.
+func (runInfo *runInfoStruct) runCloseStmt(stmt *ast.CloseStmt) {
+	runInfo.expr = stmt.Expr
+	runInfo.invokeExpr()
+	if runInfo.err != nil {
+		return
+	}
+	if runInfo.rv.Kind() == reflect.Chan {
+		ch := runInfo.rv
+		runInfo.rv = nilValue
+		if !runInfo.options.Debug {
+			// captures panic
+			defer recoverFunc(runInfo)
+		}
+		ch.Close()
+		return
+	}
+	runInfo.err = newStringError(stmt, "type cannot be "+runInfo.rv.Kind().String()+" for close")
+	runInfo.rv = nilValue
+}
+
+// runChanStmt executes a channel receive statement.
+func (runInfo *runInfoStruct) runChanStmt(stmt *ast.ChanStmt) {
+	runInfo.expr = stmt.RHS
+	runInfo.invokeExpr()
+	if runInfo.err != nil {
+		return
+	}
+	if runInfo.rv.Kind() == reflect.Interface && !runInfo.rv.IsNil() {
+		runInfo.rv = runInfo.rv.Elem()
+	}
+
+	if runInfo.rv.Kind() != reflect.Chan {
+		// rhs is not channel
+		runInfo.err = newStringError(stmt, "receive from non-chan type "+runInfo.rv.Kind().String())
+		runInfo.rv = nilValue
+		return
+	}
+
+	// rhs is channel
+	// receive from rhs channel
+	rhs := runInfo.rv
+	cases := []reflect.SelectCase{{
+		Dir:  reflect.SelectRecv,
+		Chan: reflect.ValueOf(runInfo.ctx.Done()),
+	}, {
+		Dir:  reflect.SelectRecv,
+		Chan: rhs,
+	}}
+	var chosen int
+	var ok bool
+	chosen, runInfo.rv, ok = reflect.Select(cases)
+	if chosen == 0 {
+		runInfo.err = ErrInterrupt
+		runInfo.rv = nilValue
+		return
+	}
+
+	rhs = runInfo.rv // store rv in rhs temporarily
+
+	if stmt.OkExpr != nil {
+		// set ok to OkExpr
+		if ok {
+			runInfo.rv = trueValue
+		} else {
+			runInfo.rv = falseValue
+		}
+		runInfo.expr = stmt.OkExpr
+		runInfo.invokeLetExpr()
+		// TODO: ok to ignore error?
+	}
+
+	if ok {
+		// set rv to lhs
+		runInfo.rv = rhs
+		runInfo.expr = stmt.LHS
+		runInfo.invokeLetExpr()
+		if runInfo.err != nil {
+			return
+		}
+	} else {
+		runInfo.rv = nilValue
+	}
 }


### PR DESCRIPTION
## Summary

The four largest functions in the VM held all their logic inside a single giant type switch:

| Function | Before | After |
|---|---|---|
| `invokeExpr` (vmExpr.go) | 787 lines | 113-line dispatcher + 17 methods |
| `runSingleStmt` (vmStmt.go) | 767 lines | 100-line dispatcher + 16 methods |
| `invokeLetExpr` (vmLetExpr.go) | 378 lines | 33-line dispatcher + 7 methods |
| `invokeOperator` (vmOperator.go) | 279 lines | 25-line dispatcher + 4 methods |

The type switches now only dispatch; each case body moved into its own method taking the typed AST node (e.g. `invokeArrayExpr(expr *ast.ArrayExpr)`), matching the existing `funcExpr`/`callExpr` naming. Two hotspots are split one level further:

- `ForStmt` → `runForSliceStmt` / `runForMapStmt` / `runForChanStmt`
- let `ItemExpr` → `invokeLetItemSlice` / `invokeLetItemMap` / `invokeLetItemString`

This is a pure code move — no behavior change. The `defer recoverFunc(runInfo)` panic capture in `ChanExpr`/`CloseStmt` keeps its effective scope, and the for-loops still preserve `rv` on `ErrReturn`.

## Benchmarks

No regression — everything got faster (benchstat, n=6): the much smaller stack frames make the recursive dispatch cheaper.

```
ArithmeticInt-16    696.9n ±  4%   572.4n ± 5%  -17.85% (p=0.002 n=6)
ArithmeticFloat-16  767.5n ±  5%   638.8n ± 2%  -16.77% (p=0.002 n=6)
Comparison-16       1.256µ ± 23%   1.060µ ± 5%  -15.61% (p=0.002 n=6)
Loop-16             35.77µ ± 17%   25.30µ ± 2%  -29.26% (p=0.002 n=6)
Fibonacci-16        1.516m ±  5%   1.265m ± 6%  -16.53% (p=0.002 n=6)
StringConcat-16     877.9n ±  2%   772.5n ± 4%  -12.01% (p=0.002 n=6)
VarAccess-16        1.360µ ±  6%   1.209µ ± 5%  -11.10% (p=0.002 n=6)
MapAccess-16        1.912µ ±  5%   1.700µ ± 6%  -11.11% (p=0.002 n=6)
ArrayAccess-16      1.388µ ±  9%   1.150µ ± 4%  -17.15% (p=0.002 n=6)
FuncCall-16         1.341µ ±  4%   1.231µ ± 4%   -8.24% (p=0.002 n=6)
geomean                                          -12.10%
```

## Testing

- `go build ./...`, `go vet ./vm/`
- `go test ./...` — all packages pass
- `go test -race ./vm/` — pass